### PR TITLE
Implement ActivityPub publishing for content articles

### DIFF
--- a/server/routes/@me/outbox.ts
+++ b/server/routes/@me/outbox.ts
@@ -1,34 +1,100 @@
-// routes/users/[username]/outbox.get.ts
-export default defineEventHandler((event) => {
-  // TODO: Fetch actual activities from a data store
-  // Returning an empty collection for this minimal example.
-  const activities: any[] = [
-    // Example structure if you had data:
-    // {
-    //     "@context": "https://www.w3.org/ns/activitystreams",
-    //     "id": `${baseUrl}/activities/some-unique-id-1`, // Note: Use baseUrl from data.ts
-    //     "type": "Create",
-    //     "actor": user.actorUrl,
-    //     "published": new Date().toISOString(),
-    //     "to": ["https://www.w3.org/ns/activitystreams#Public"],
-    //     "object": {
-    //         "id": `${baseUrl}/notes/some-unique-note-id-1`,
-    //         "type": "Note",
-    //         "attributedTo": user.actorUrl,
-    //         "content": "This is my first note!",
-    //         "published": new Date().toISOString(),
-    //          "to": ["https://www.w3.org/ns/activitystreams#Public"],
-    //     }
-    // }
-  ];
+import { stringifyMarkdown } from "@nuxtjs/mdc/runtime"
+import { toHtml } from "hast-util-to-html"
+import remarkGfm from "remark-gfm"
+import remarkParse from "remark-parse"
+import remarkRehype from "remark-rehype"
+import { unified } from "unified"
+import { me, PUBLIC_AUDIENCE, setJsonLdHeader } from "../../utils/federation"
 
-  setJsonLdHeader(event); // Set the Content-Type header to application/ld+json with the ActivityStreams profile
-  return { // sendJson returns the body
-    '@context': 'https://www.w3.org/ns/activitystreams',
-    id: 'https://changkyun.kim/@me/outbox',
-    type: 'OrderedCollection',
-    totalItems: activities.length, // Should be total count in DB
-    orderedItems: activities // Needs pagination in a real implementation
-    // first: `${user.outbox}?page=1`, // Example pagination link
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkRehype, { allowDangerousHtml: true })
+
+const siteOrigin = new URL(me.id).origin
+
+async function renderMarkdown(markdown: string): Promise<string> {
+  if (!markdown) {
+    return ''
   }
-});
+  const tree = processor.parse(markdown)
+  const result = await processor.run(tree)
+  return toHtml(result, { allowDangerousHtml: true })
+}
+
+function resolveArticleUrl(path?: string | null): string | null {
+  if (!path) {
+    return null
+  }
+  const normalized = path.startsWith('/') ? path : `/${path}`
+  return `${siteOrigin}${normalized}`
+}
+
+export default defineEventHandler(async (event) => {
+  const [blogEntries, appEntries] = await Promise.all([
+    queryCollection(event, 'blog').order('createdAt', 'DESC').all(),
+    queryCollection(event, 'app').order('createdAt', 'DESC').all(),
+  ])
+
+  const entries = [...(blogEntries ?? []), ...(appEntries ?? [])]
+  entries.sort((a, b) => {
+    const aDate = a?.createdAt ? new Date(a.createdAt).getTime() : 0
+    const bDate = b?.createdAt ? new Date(b.createdAt).getTime() : 0
+    return bDate - aDate
+  })
+
+  const activities: CreateActivity[] = []
+  for (const entry of entries) {
+    const articleUrl = resolveArticleUrl(entry?.path || entry?.id)
+    if (!articleUrl) {
+      continue
+    }
+
+    const markdown = entry?.body ? (await stringifyMarkdown(entry.body, {})) ?? '' : ''
+    const contentHtml = await renderMarkdown(markdown)
+    const isHtml = Boolean(contentHtml)
+    const publishedAt = entry?.createdAt ? new Date(entry.createdAt).toISOString() : new Date().toISOString()
+    const title = entry?.title || entry?.stem || articleUrl
+
+    const article: ObjectT = {
+      id: articleUrl,
+      type: 'Article',
+      name: title,
+      attributedTo: me.id,
+      content: isHtml ? contentHtml : markdown,
+      mediaType: isHtml ? 'text/html' : markdown ? 'text/markdown' : undefined,
+      published: publishedAt,
+      summary: entry?.description,
+      url: articleUrl,
+      to: [PUBLIC_AUDIENCE],
+      source: markdown
+        ? {
+          content: markdown,
+          mediaType: 'text/markdown',
+        }
+        : undefined,
+    }
+
+    const createActivity: CreateActivity = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: `${articleUrl}#create`,
+      type: 'Create',
+      actor: me.id,
+      object: article,
+      published: publishedAt,
+      to: [PUBLIC_AUDIENCE],
+    }
+
+    activities.push(createActivity)
+  }
+
+  setJsonLdHeader(event)
+
+  return {
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    id: me.outbox,
+    type: 'OrderedCollection',
+    totalItems: activities.length,
+    orderedItems: activities,
+  }
+})

--- a/server/tasks/ap/deliver.ts
+++ b/server/tasks/ap/deliver.ts
@@ -1,3 +1,10 @@
+import { sendActivity } from "../../utils/federation"
+
+type DeliverPayload = {
+  activity: Activity
+  target?: string | string[]
+}
+
 export default defineTask({
   meta: {
     name: 'ap:deliver',
@@ -5,13 +12,43 @@ export default defineTask({
   },
   async run(event) {
     const db = useDatabase()
-    const { activity } = event.payload
-    const { rows: receipants } = await db.sql`SELECT * FROM activity WHERE object = ${activity.actor} AND type = 'Follow'`
+    const { activity, target } = event.payload as DeliverPayload
 
-    for (const receipant of receipants ?? []) {
-      const actor = receipant.actor_id as string
-      // await sendActivity(activity, actor)
+    const recipients = new Set<string>()
+    if (Array.isArray(target)) {
+      for (const actor of target) {
+        if (actor) {
+          recipients.add(actor)
+        }
+      }
+    } else if (target) {
+      recipients.add(target)
     }
-    return { result: true }
+
+    const actorId = typeof activity.actor === 'string' ? activity.actor : activity.actor?.id
+    if (!recipients.size && actorId) {
+      const { rows } = await db.sql`SELECT actor_id FROM activity WHERE object = ${actorId} AND type = 'Follow'`
+      for (const row of rows ?? []) {
+        const follower = row.actor_id as string | null
+        if (follower) {
+          recipients.add(follower)
+        }
+      }
+    }
+
+    let delivered = 0
+    const failures: { actor: string; message: string }[] = []
+
+    for (const actor of recipients) {
+      try {
+        await sendActivity(activity, actor)
+        delivered += 1
+      } catch (error) {
+        console.error('Failed to deliver ActivityPub activity', error)
+        failures.push({ actor, message: (error as Error).message })
+      }
+    }
+
+    return { result: true, delivered, failed: failures }
   }
 })

--- a/server/tasks/ap/sendActivity.ts
+++ b/server/tasks/ap/sendActivity.ts
@@ -1,7 +1,8 @@
-import type { Accept, Create } from "@csjewell-activitypub/types"
+import { sendActivity } from "../../utils/federation"
+
 type Payload = {
-  activity: Accept | Create
-  target: string
+  activity: Activity
+  target?: string | string[]
 }
 export default defineTask({
   meta: {
@@ -11,12 +12,42 @@ export default defineTask({
   async run(event) {
     const db = useDatabase()
     const { activity, target } = event.payload as Payload
-    const { rows: receipants } = await db.sql`SELECT * FROM activity WHERE object = ${activity.actor} AND type = 'Follow'`
 
-    for (const receipant of receipants ?? []) {
-      const actor = receipant.actor_id as string
-      // TODO: Implement the sendActivity function to send the activity to the target actor
+    const recipients = new Set<string>()
+    if (Array.isArray(target)) {
+      for (const actor of target) {
+        if (actor) {
+          recipients.add(actor)
+        }
+      }
+    } else if (target) {
+      recipients.add(target)
     }
-    return { result: true }
+
+    const actorId = typeof activity.actor === 'string' ? activity.actor : activity.actor?.id
+    if (!recipients.size && actorId) {
+      const { rows } = await db.sql`SELECT actor_id FROM activity WHERE object = ${actorId} AND type = 'Follow'`
+      for (const row of rows ?? []) {
+        const follower = row.actor_id as string | null
+        if (follower) {
+          recipients.add(follower)
+        }
+      }
+    }
+
+    let delivered = 0
+    const failures: { actor: string; message: string }[] = []
+
+    for (const actor of recipients) {
+      try {
+        await sendActivity(activity, actor)
+        delivered += 1
+      } catch (error) {
+        console.error('Failed to send ActivityPub activity', error)
+        failures.push({ actor, message: (error as Error).message })
+      }
+    }
+
+    return { result: true, delivered, failed: failures }
   }
 })

--- a/server/utils/types.d.ts
+++ b/server/utils/types.d.ts
@@ -48,6 +48,10 @@ interface PublicKey {
 
 interface Actor {
   id: string
+  inbox?: string
+  endpoints?: {
+    sharedInbox?: string
+  }
   publicKey?: PublicKey
 }
 
@@ -57,8 +61,15 @@ interface ObjectT {
   name: string
   attributedTo?: string
   content?: string
+  mediaType?: string
   published?: DateLike
   to?: string[]
+  summary?: string
+  url?: string
+  source?: {
+    content: string
+    mediaType: string
+  }
 }
 
 interface Note extends ObjectT {
@@ -70,9 +81,10 @@ interface Activity {
   id: string
   type: ActivityType
   actor: string | Actor
-  // published: DateLike
-  // to: string | string[]
-  // object?: ObjectT | ObjectT[]
+  published?: DateLike
+  to?: string | string[]
+  cc?: string | string[]
+  object?: ObjectT | ObjectT[] | string
 }
 
 interface AcceptActivity extends Activity {
@@ -84,6 +96,11 @@ interface FollowActivity extends Activity {
   type: 'Follow'
   actor: string
   object: string
+}
+
+interface CreateActivity extends Activity {
+  type: 'Create'
+  object: ObjectT | string
 }
 
 interface ReplyActivity extends Activity {


### PR DESCRIPTION
## Summary
- render the @me outbox as ActivityPub Create activities backed by markdown content converted to HTML
- wire up ActivityPub delivery helpers and background tasks to sign and POST activities from the edge-safe implementation
- refine ActivityPub utilities, types, and the follow test task to use proper HTTP signatures and metadata

## Testing
- yarn build *(fails: project requires Node >=22 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4610a04483308a67ced8672ec740