### PR TITLE
Add ActivityPub inbox endpoints and broadcast task

### DIFF
--- a/server/plugins/activitypub.ts
+++ b/server/plugins/activitypub.ts
@@ -1,3 +1,4 @@
+import { ensureActivitySchema } from "../utils/federation"
 import { buildCreateActivityFromEntry, type ContentEntry } from "../utils/outboxHelpers"
 
 const FEDERATED_COLLECTIONS = new Set(['/blog/', '/app/'])
@@ -16,15 +17,26 @@ async function broadcastDocument(document: ContentEntry) {
     return
   }
 
+  const db = useDatabase()
+
   try {
-    const db = useDatabase()
     const { rows } = await db.sql`SELECT 1 FROM activity WHERE activity_id = ${activity.id} LIMIT 1`
     if (rows && rows.length) {
       return
     }
   } catch (error) {
-    console.error('Failed checking existing ActivityPub activity', error)
-    return
+    const message = (error as Error)?.message ?? ""
+    if (/no such table: activity/i.test(message) || /no column named (activity_id|payload)/i.test(message)) {
+      try {
+        await ensureActivitySchema(db)
+      } catch (migrationError) {
+        console.error('Failed to prepare ActivityPub activity table', migrationError)
+        return
+      }
+    } else {
+      console.error('Failed checking existing ActivityPub activity', error)
+      return
+    }
   }
 
   try {

--- a/server/plugins/activitypub.ts
+++ b/server/plugins/activitypub.ts
@@ -24,6 +24,7 @@ async function broadcastDocument(document: ContentEntry) {
     }
   } catch (error) {
     console.error('Failed checking existing ActivityPub activity', error)
+    return
   }
 
   try {
@@ -36,17 +37,13 @@ async function broadcastDocument(document: ContentEntry) {
 }
 
 export default defineNitroPlugin((nitroApp) => {
-  nitroApp.hooks.hook('content:file:afterInsert', async (document) => {
+  const handleContentUpdate = async (document: ContentEntry) => {
     if (!isFederatedDocument(document)) {
       return
     }
     await broadcastDocument(document)
-  })
+  }
 
-  nitroApp.hooks.hook('content:file:afterUpdate', async (document) => {
-    if (!isFederatedDocument(document)) {
-      return
-    }
-    await broadcastDocument(document)
-  })
+  nitroApp.hooks.hook('content:file:afterInsert', handleContentUpdate)
+  nitroApp.hooks.hook('content:file:afterUpdate', handleContentUpdate)
 })

--- a/server/plugins/activitypub.ts
+++ b/server/plugins/activitypub.ts
@@ -1,0 +1,52 @@
+import { buildCreateActivityFromEntry, type ContentEntry } from "../utils/outboxHelpers"
+
+const FEDERATED_COLLECTIONS = new Set(['/blog/', '/app/'])
+
+function isFederatedDocument(document: Record<string, any>): boolean {
+  const path = (document?.path || document?._path || '') as string
+  if (!path || document?.draft) {
+    return false
+  }
+  return Array.from(FEDERATED_COLLECTIONS).some((prefix) => path.startsWith(prefix))
+}
+
+async function broadcastDocument(document: ContentEntry) {
+  const activity = await buildCreateActivityFromEntry(document)
+  if (!activity) {
+    return
+  }
+
+  try {
+    const db = useDatabase()
+    const { rows } = await db.sql`SELECT 1 FROM activity WHERE activity_id = ${activity.id} LIMIT 1`
+    if (rows && rows.length) {
+      return
+    }
+  } catch (error) {
+    console.error('Failed checking existing ActivityPub activity', error)
+  }
+
+  try {
+    await runTask('ap:broadcastCreate', {
+      payload: { activity },
+    })
+  } catch (error) {
+    console.error('Failed to schedule ActivityPub broadcast for content document', error)
+  }
+}
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('content:file:afterInsert', async (document) => {
+    if (!isFederatedDocument(document)) {
+      return
+    }
+    await broadcastDocument(document)
+  })
+
+  nitroApp.hooks.hook('content:file:afterUpdate', async (document) => {
+    if (!isFederatedDocument(document)) {
+      return
+    }
+    await broadcastDocument(document)
+  })
+})

--- a/server/routes/@me/followers.ts
+++ b/server/routes/@me/followers.ts
@@ -1,14 +1,25 @@
+import { me, setJsonLdHeader } from "../../utils/federation"
+
 export default defineEventHandler(async (event) => {
   const db = useDatabase()
-  const { rows: followers } = await db.sql`SELECT * FROM activity WHERE object = ${me.id} AND type = 'Follow'`
-  const items = followers?.map((follower) => follower.actor_id as string) ?? []
-  const totalItems = items.length
+  const { rows: followers } = await db.sql`SELECT activity_id, actor_id, payload FROM activity WHERE object = ${me.id} AND type = 'Follow' ORDER BY created_at DESC`
+  const orderedItems = followers?.map((row) => {
+    if (typeof row?.payload === 'string') {
+      try {
+        return JSON.parse(row.payload)
+      } catch {
+        // fall back to actor URI
+      }
+    }
+    return row?.actor_id as string
+  }).filter(Boolean) ?? []
+  const totalItems = orderedItems.length
   setJsonLdHeader(event)
   return {
     '@context': 'https://www.w3.org/ns/activitystreams',
     id: 'https://changkyun.kim/@me/followers',
-    type: 'Collection',
+    type: 'OrderedCollection',
     totalItems,
-    items,
+    orderedItems,
   }
 })

--- a/server/routes/@me/following.ts
+++ b/server/routes/@me/following.ts
@@ -1,10 +1,26 @@
+import { me, setJsonLdHeader } from "../../utils/federation"
+
 export default defineEventHandler(async (event) => {
+  const db = useDatabase()
+  const { rows: following } = await db.sql`SELECT activity_id, object, payload FROM activity WHERE actor_id = ${me.id} AND type = 'Follow' ORDER BY created_at DESC`
+
+  const orderedItems = following?.map((row) => {
+    if (typeof row?.payload === 'string') {
+      try {
+        return JSON.parse(row.payload)
+      } catch {
+        // ignore parsing error and fall back to object URI
+      }
+    }
+    return row?.object as string
+  }).filter(Boolean) ?? []
+
   setJsonLdHeader(event)
   return {
     '@context': 'https://www.w3.org/ns/activitystreams',
     id: 'https://changkyun.kim/@me/following',
     type: 'OrderedCollection',
-    totalItems: 0, // Should be total count in DB
-    orderedItems: [], // Needs pagination in a real implementation
+    totalItems: orderedItems.length,
+    orderedItems,
   }
 })

--- a/server/routes/@me/inbox.ts
+++ b/server/routes/@me/inbox.ts
@@ -1,0 +1,32 @@
+import { me, setJsonLdHeader } from "../../utils/federation"
+
+export default defineEventHandler(async (event) => {
+  const db = useDatabase()
+  const { rows } = await db.sql`SELECT activity_id, payload, actor_id, type, object FROM activity WHERE type != 'Create' AND (object = ${me.id} OR actor_id != ${me.id}) ORDER BY created_at DESC`
+
+  const orderedItems = rows?.map((row) => {
+    if (typeof row?.payload === 'string') {
+      try {
+        return JSON.parse(row.payload)
+      } catch {
+        // fall back to minimal activity representation
+      }
+    }
+    return {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: row?.activity_id,
+      type: row?.type ?? 'Follow',
+      actor: row?.actor_id,
+      object: row?.object,
+    }
+  }).filter(Boolean) ?? []
+
+  setJsonLdHeader(event)
+  return {
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    id: me.inbox,
+    type: 'OrderedCollection',
+    totalItems: orderedItems.length,
+    orderedItems,
+  }
+})

--- a/server/routes/@me/inbox.ts
+++ b/server/routes/@me/inbox.ts
@@ -1,31 +1,156 @@
 import { me, setJsonLdHeader } from "../../utils/federation"
 
+const siteOrigin = new URL(me.id).origin
+const LOCAL_AUDIENCE_IDS = new Set<string>([me.id, me.followers].filter(Boolean) as string[])
+
+function normalizeRecipients(value: unknown): string[] {
+  if (!value) {
+    return []
+  }
+  if (Array.isArray(value)) {
+    const recipients: string[] = []
+    for (const entry of value) {
+      recipients.push(...normalizeRecipients(entry))
+    }
+    return recipients
+  }
+  if (typeof value === "string") {
+    return [value]
+  }
+  if (typeof value === "object") {
+    const candidate = value as { id?: string | null }
+    return candidate?.id ? [candidate.id] : []
+  }
+  return []
+}
+
+function targetsLocalObject(value: unknown): boolean {
+  if (!value) {
+    return false
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => targetsLocalObject(entry))
+  }
+  if (typeof value === "string") {
+    return value === me.id || value.startsWith(siteOrigin)
+  }
+  if (typeof value === "object") {
+    const candidate = value as Record<string, any>
+    const identifier = typeof candidate.id === "string" ? candidate.id : null
+    if (identifier && (identifier === me.id || identifier.startsWith(siteOrigin))) {
+      return true
+    }
+    const inReplyTo = candidate?.inReplyTo
+    if (typeof inReplyTo === "string" && inReplyTo.startsWith(siteOrigin)) {
+      return true
+    }
+    if (candidate?.object && targetsLocalObject(candidate.object)) {
+      return true
+    }
+  }
+  return false
+}
+
+function isRelevantActivity(activity: Activity): boolean {
+  if (!activity) {
+    return false
+  }
+
+  if (targetsLocalObject(activity.object)) {
+    return true
+  }
+
+  const recipients = [
+    ...normalizeRecipients(activity.to),
+    ...normalizeRecipients((activity as any).cc),
+    ...normalizeRecipients((activity as any).bto),
+    ...normalizeRecipients((activity as any).bcc),
+    ...normalizeRecipients((activity as any).audience),
+  ]
+
+  return recipients.some((recipient) => LOCAL_AUDIENCE_IDS.has(recipient))
+}
+
+function parseStoredActivity(row: any): Activity | null {
+  if (typeof row?.payload !== "string" || !row.payload) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(row.payload) as Activity
+    if (!parsed || typeof parsed !== "object") {
+      return null
+    }
+
+    const normalized: Activity = { ...parsed }
+    if (!normalized.id && typeof row?.activity_id === "string" && row.activity_id) {
+      normalized.id = row.activity_id
+    }
+    return normalized
+  } catch (error) {
+    console.warn("Failed to parse stored ActivityPub payload", error)
+    return null
+  }
+}
+
+function createFallbackActivity(row: any): Activity | null {
+  const activityId = typeof row?.activity_id === "string" && row.activity_id ? row.activity_id : null
+  const actorId = typeof row?.actor_id === "string" && row.actor_id ? row.actor_id : null
+  const type = typeof row?.type === "string" && row.type ? row.type : "Activity"
+
+  if (!activityId || !actorId) {
+    return null
+  }
+
+  const fallback: Activity = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    id: activityId,
+    type: type as ActivityType,
+    actor: actorId,
+  }
+
+  if (typeof row?.object !== "undefined") {
+    fallback.object = row.object as any
+  }
+
+  return fallback
+}
+
 export default defineEventHandler(async (event) => {
   const db = useDatabase()
-  const { rows } = await db.sql`SELECT activity_id, payload, actor_id, type, object FROM activity WHERE type != 'Create' AND (object = ${me.id} OR actor_id != ${me.id}) ORDER BY created_at DESC`
+  const originMatch = `${siteOrigin}/%`
+  const payloadActorMatch = `%${me.id}%`
+  const payloadOriginMatch = `%${siteOrigin}/%`
+
+  const { rows } = await db.sql`SELECT activity_id, payload, actor_id, type, object FROM activity
+    WHERE type != 'Create'
+      AND (
+        object = ${me.id}
+        OR object LIKE ${originMatch}
+        OR payload LIKE ${payloadActorMatch}
+        OR payload LIKE ${payloadOriginMatch}
+      )
+    ORDER BY created_at DESC`
 
   const orderedItems = rows?.map((row) => {
-    if (typeof row?.payload === 'string') {
-      try {
-        return JSON.parse(row.payload)
-      } catch {
-        // fall back to minimal activity representation
-      }
+    const parsed = parseStoredActivity(row)
+    if (parsed && isRelevantActivity(parsed)) {
+      return parsed
     }
-    return {
-      '@context': 'https://www.w3.org/ns/activitystreams',
-      id: row?.activity_id,
-      type: row?.type ?? 'Follow',
-      actor: row?.actor_id,
-      object: row?.object,
+
+    const fallback = createFallbackActivity(row)
+    if (fallback && isRelevantActivity(fallback)) {
+      return fallback
     }
-  }).filter(Boolean) ?? []
+
+    return null
+  }).filter((activity): activity is Activity => Boolean(activity)) ?? []
 
   setJsonLdHeader(event)
   return {
-    '@context': 'https://www.w3.org/ns/activitystreams',
+    "@context": "https://www.w3.org/ns/activitystreams",
     id: me.inbox,
-    type: 'OrderedCollection',
+    type: "OrderedCollection",
     totalItems: orderedItems.length,
     orderedItems,
   }

--- a/server/routes/@me/outbox.ts
+++ b/server/routes/@me/outbox.ts
@@ -1,34 +1,5 @@
-import { stringifyMarkdown } from "@nuxtjs/mdc/runtime"
-import { toHtml } from "hast-util-to-html"
-import remarkGfm from "remark-gfm"
-import remarkParse from "remark-parse"
-import remarkRehype from "remark-rehype"
-import { unified } from "unified"
-import { me, PUBLIC_AUDIENCE, setJsonLdHeader } from "../../utils/federation"
-
-const processor = unified()
-  .use(remarkParse)
-  .use(remarkGfm)
-  .use(remarkRehype, { allowDangerousHtml: true })
-
-const siteOrigin = new URL(me.id).origin
-
-async function renderMarkdown(markdown: string): Promise<string> {
-  if (!markdown) {
-    return ''
-  }
-  const tree = processor.parse(markdown)
-  const result = await processor.run(tree)
-  return toHtml(result, { allowDangerousHtml: true })
-}
-
-function resolveArticleUrl(path?: string | null): string | null {
-  if (!path) {
-    return null
-  }
-  const normalized = path.startsWith('/') ? path : `/${path}`
-  return `${siteOrigin}${normalized}`
-}
+import { me, setJsonLdHeader } from "../../utils/federation"
+import { buildCreateActivityFromEntry } from "../../utils/outboxHelpers"
 
 export default defineEventHandler(async (event) => {
   const [blogEntries, appEntries] = await Promise.all([
@@ -45,47 +16,10 @@ export default defineEventHandler(async (event) => {
 
   const activities: CreateActivity[] = []
   for (const entry of entries) {
-    const articleUrl = resolveArticleUrl(entry?.path || entry?.id)
-    if (!articleUrl) {
-      continue
+    const activity = await buildCreateActivityFromEntry(entry)
+    if (activity) {
+      activities.push(activity)
     }
-
-    const markdown = entry?.body ? (await stringifyMarkdown(entry.body, {})) ?? '' : ''
-    const contentHtml = await renderMarkdown(markdown)
-    const isHtml = Boolean(contentHtml)
-    const publishedAt = entry?.createdAt ? new Date(entry.createdAt).toISOString() : new Date().toISOString()
-    const title = entry?.title || entry?.stem || articleUrl
-
-    const article: ObjectT = {
-      id: articleUrl,
-      type: 'Article',
-      name: title,
-      attributedTo: me.id,
-      content: isHtml ? contentHtml : markdown,
-      mediaType: isHtml ? 'text/html' : markdown ? 'text/markdown' : undefined,
-      published: publishedAt,
-      summary: entry?.description,
-      url: articleUrl,
-      to: [PUBLIC_AUDIENCE],
-      source: markdown
-        ? {
-          content: markdown,
-          mediaType: 'text/markdown',
-        }
-        : undefined,
-    }
-
-    const createActivity: CreateActivity = {
-      '@context': 'https://www.w3.org/ns/activitystreams',
-      id: `${articleUrl}#create`,
-      type: 'Create',
-      actor: me.id,
-      object: article,
-      published: publishedAt,
-      to: [PUBLIC_AUDIENCE],
-    }
-
-    activities.push(createActivity)
   }
 
   setJsonLdHeader(event)

--- a/server/routes/inbox.post.ts
+++ b/server/routes/inbox.post.ts
@@ -1,4 +1,4 @@
-import { handleInboxPost } from "../../utils/inbox"
+import { handleInboxPost } from "../utils/inbox"
 
 export default defineEventHandler(async (event) => {
   return await handleInboxPost(event)

--- a/server/tasks/ap/broadcastCreate.ts
+++ b/server/tasks/ap/broadcastCreate.ts
@@ -1,0 +1,65 @@
+import { ensureActivitySchema, me } from "../../utils/federation"
+
+type BroadcastPayload = {
+  activity: CreateActivity
+}
+
+export default defineTask({
+  meta: {
+    name: 'ap:broadcastCreate',
+    description: 'Broadcast new Create activities to all followers',
+  },
+  async run(event) {
+    const db = useDatabase()
+    const { activity } = event.payload as BroadcastPayload
+
+    if (!activity || activity.type !== 'Create') {
+      return { result: false, reason: 'invalid-activity' }
+    }
+
+    const activityId = activity.id
+    const actorId = typeof activity.actor === 'string' ? activity.actor : activity.actor?.id || me.id
+    const objectId = typeof activity.object === 'string'
+      ? activity.object
+      : Array.isArray(activity.object)
+        ? JSON.stringify(activity.object)
+        : (activity.object as Record<string, any> | undefined)?.id || null
+
+    if (!activityId || !objectId) {
+      return { result: false, reason: 'missing-identifiers' }
+    }
+
+    const payload = JSON.stringify(activity)
+    const insertActivity = () => db.sql`INSERT INTO activity (
+      activity_id, actor_id, type, object, payload
+    ) VALUES (
+      ${activityId}, ${actorId}, ${activity.type}, ${objectId}, ${payload}
+    )`
+
+    try {
+      await insertActivity()
+    } catch (error) {
+      const message = (error as Error)?.message ?? ''
+      if (/no such table: activity/i.test(message)) {
+        await ensureActivitySchema(db)
+        await insertActivity()
+      } else if (/no column named (activity_id|payload)/i.test(message)) {
+        await ensureActivitySchema(db)
+        await insertActivity()
+      } else if (/unique constraint failed|duplicate/i.test(message)) {
+        return { result: false, reason: 'duplicate' }
+      } else {
+        console.error('Failed storing Create activity before broadcast', error)
+        throw error
+      }
+    }
+
+    await runTask('ap:sendActivity', {
+      payload: {
+        activity,
+      },
+    })
+
+    return { result: true }
+  },
+})

--- a/server/tasks/db/seed.ts
+++ b/server/tasks/db/seed.ts
@@ -1,3 +1,5 @@
+import { generateRsaKeyPair } from "../../utils/auth"
+
 export default defineTask({
   meta: {
     name: 'db:seed',
@@ -13,6 +15,7 @@ export default defineTask({
       actor_id TEXT,
       type TEXT,
       object TEXT,
+      payload TEXT,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );`
     await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_activity_activity_id ON activity(activity_id);`

--- a/server/utils/federation.ts
+++ b/server/utils/federation.ts
@@ -1,4 +1,7 @@
+import { createHash, randomUUID } from 'node:crypto';
 import type { H3Event } from 'h3';
+
+import { verifySignature } from './auth';
 
 /**
  * Fetches an Actor from a given URL using ActivityPub protocol.
@@ -158,37 +161,104 @@ export async function ensureActivitySchema(db: ReturnType<typeof useDatabase>) {
  * @returns A promise that resolves when the request has been processed
  * @throws May throw an error if signature verification fails internally
  */
-export async function acceptFollowRequest(event: H3Event, activity: FollowActivity): Promise<void> {
+export async function acceptFollowRequest(event: H3Event, activity: FollowActivity): Promise<AcceptActivity | void> {
   const db = useDatabase()
-  const { id: activity_id, actor, type, object: fallowee } = activity
-  const isValid = await verifySignature(event, actor)
+
+  const actorId = typeof activity.actor === 'string'
+    ? activity.actor
+    : typeof (activity.actor as Actor | undefined)?.id === 'string'
+      ? (activity.actor as Actor).id
+      : null
+
+  if (!actorId) {
+    return sendError(event, createError({ statusCode: 400, statusMessage: 'Follow request missing actor' }))
+  }
+
+  const objectValue = activity.object as unknown
+  const followTarget = typeof objectValue === 'string'
+    ? objectValue
+    : typeof (objectValue as { id?: string })?.id === 'string'
+      ? (objectValue as { id: string }).id
+      : null
+
+  if (!followTarget) {
+    return sendError(event, createError({ statusCode: 400, statusMessage: 'Follow request missing object' }))
+  }
+
+  if (followTarget !== me.id && followTarget !== me.followers) {
+    return sendError(event, createError({ statusCode: 404, statusMessage: 'Unknown follow target' }))
+  }
+
+  const isValid = await verifySignature(event, actorId)
   if (!isValid) {
     return
   }
-  const payload = JSON.stringify(activity)
+
+  const followActivityId = typeof activity.id === 'string' && activity.id
+    ? activity.id
+    : randomUUID()
+
+  const followActivity: FollowActivity = {
+    '@context': activity['@context'] ?? 'https://www.w3.org/ns/activitystreams',
+    id: followActivityId,
+    type: 'Follow',
+    actor: actorId,
+    object: me.id,
+  }
+
+  const payload = JSON.stringify(followActivity)
+
   const insertActivity = () => db.sql`INSERT INTO activity (
     activity_id, actor_id, type, object, payload
   ) VALUES (
-    ${activity_id}, ${actor}, ${type}, ${fallowee}, ${payload}
+    ${followActivity.id}, ${followActivity.actor}, ${followActivity.type}, ${followActivity.object}, ${payload}
   )`
 
-  let insertResult
+  const updateStoredFollow = () => db.sql`UPDATE activity
+    SET actor_id = ${followActivity.actor}, object = ${followActivity.object}, payload = ${payload}
+    WHERE activity_id = ${followActivity.id}`
+
+  const ensureSchemaAndRetry = async () => {
+    try {
+      await ensureActivitySchema(db)
+    } catch (migrationError) {
+      console.error('Failed migrating activity table', migrationError)
+      return false
+    }
+
+    try {
+      await insertActivity()
+      return true
+    } catch (retryError) {
+      const retryMessage = (retryError as Error)?.message ?? ''
+      if (/unique constraint failed|duplicate/i.test(retryMessage)) {
+        try {
+          await updateStoredFollow()
+        } catch (updateError) {
+          console.error('Failed updating stored follow activity', updateError)
+          return false
+        }
+        return true
+      }
+      console.error('Failed inserting follow activity', retryError)
+      return false
+    }
+  }
+
   try {
-    insertResult = await insertActivity()
+    await insertActivity()
   } catch (error) {
     const message = (error as Error)?.message ?? ''
-    if (/no column named (activity_id|payload)/i.test(message)) {
-      try {
-        await ensureActivitySchema(db)
-      } catch (migrationError) {
-        console.error('Failed migrating activity table', migrationError)
+    if (/no such table: activity/i.test(message) || /no column named (activity_id|payload)/i.test(message)) {
+      const migrated = await ensureSchemaAndRetry()
+      if (!migrated) {
         return sendError(event, createError({ statusCode: 500, statusMessage: 'Failed accepting follow request' }))
       }
-
+    } else if (/unique constraint failed|duplicate/i.test(message)) {
       try {
-        insertResult = await insertActivity()
-      } catch (retryError) {
-        console.error('Failed inserting follow activity', retryError)
+        await updateStoredFollow()
+      } catch (updateError) {
+        console.error('Failed updating stored follow activity', updateError)
         return sendError(event, createError({ statusCode: 500, statusMessage: 'Failed accepting follow request' }))
       }
     } else {
@@ -197,25 +267,29 @@ export async function acceptFollowRequest(event: H3Event, activity: FollowActivi
     }
   }
 
-  const { success, lastInsertRowid } = insertResult
-  if (!success) {
-    return sendError(event, createError({ statusCode: 400, statusMessage: 'Failed accepting follow request' }))
-  }
+  const acceptHash = createHash('sha256')
+    .update(`${actorId}|${followActivity.id}`)
+    .digest('hex')
+
   const acceptActivity: AcceptActivity = {
     '@context': 'https://www.w3.org/ns/activitystreams',
-    id: `${me.id}#accept-${lastInsertRowid}`,
+    id: `${me.id}#accept-${acceptHash}`,
     type: 'Accept',
     actor: me.id,
-    object: activity,
-    to: [actor],
+    object: followActivity,
+    to: [actorId],
   }
 
-  await runTask('ap:sendActivity', {
-    payload: {
-      activity: acceptActivity,
-      target: actor,
-    },
-  })
+  try {
+    await runTask('ap:sendActivity', {
+      payload: {
+        activity: acceptActivity,
+        target: actorId,
+      },
+    })
+  } catch (error) {
+    console.error('Failed scheduling Accept activity delivery', error)
+  }
 
   setJsonLdHeader(event)
   setResponseStatus(event, 202)

--- a/server/utils/inbox.ts
+++ b/server/utils/inbox.ts
@@ -1,0 +1,65 @@
+import type { H3Event } from 'h3'
+
+import { acceptFollowRequest, ensureActivitySchema, setJsonLdHeader } from './federation'
+
+async function recordActivity(activity: Activity): Promise<void> {
+  const db = useDatabase()
+  const activityId = activity.id || `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const actorId = typeof activity.actor === 'string' ? activity.actor : activity.actor?.id
+  const object = Array.isArray(activity.object)
+    ? JSON.stringify(activity.object)
+    : typeof activity.object === 'string'
+      ? activity.object
+      : activity.object && typeof activity.object === 'object'
+        ? activity.object.id || JSON.stringify(activity.object)
+        : null
+  const payload = JSON.stringify(activity)
+
+  const insertActivity = () => db.sql`INSERT INTO activity (activity_id, actor_id, type, object, payload) VALUES (
+    ${activityId}, ${actorId}, ${activity.type}, ${object}, ${payload}
+  )`
+
+  try {
+    await insertActivity()
+  } catch (error) {
+    const message = (error as Error)?.message ?? ''
+    if (/no such table: activity/i.test(message)) {
+      await ensureActivitySchema(db)
+      await insertActivity()
+      return
+    }
+    if (/no column named (activity_id|payload)/i.test(message)) {
+      await ensureActivitySchema(db)
+      await insertActivity()
+      return
+    }
+    if (/unique constraint failed|duplicate/i.test(message)) {
+      return
+    }
+    console.error('Failed recording ActivityPub inbox activity', error)
+    throw error
+  }
+}
+
+export async function handleInboxPost(event: H3Event) {
+  let activity: Activity
+  try {
+    activity = await readBody(event)
+    if (!activity || typeof activity !== 'object') {
+      return sendError(event, createError({ statusCode: 400, statusMessage: 'Invalid ActivityPub payload' }))
+    }
+  } catch (error) {
+    console.error('Failed parsing ActivityPub inbox payload', error)
+    return sendError(event, createError({ statusCode: 400, statusMessage: 'Failed to parse request body' }))
+  }
+
+  switch (activity.type) {
+    case 'Follow':
+      return await acceptFollowRequest(event, activity as FollowActivity)
+    default:
+      await recordActivity(activity)
+      setJsonLdHeader(event)
+      setResponseStatus(event, 202)
+      return { status: 'Accepted' }
+  }
+}

--- a/server/utils/inbox.ts
+++ b/server/utils/inbox.ts
@@ -1,10 +1,13 @@
+import { randomUUID } from 'node:crypto'
 import type { H3Event } from 'h3'
 
 import { acceptFollowRequest, ensureActivitySchema, setJsonLdHeader } from './federation'
 
 async function recordActivity(activity: Activity): Promise<void> {
   const db = useDatabase()
-  const activityId = activity.id || `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const activityId = typeof activity.id === 'string' && activity.id
+    ? activity.id
+    : randomUUID()
   const actorId = typeof activity.actor === 'string' ? activity.actor : activity.actor?.id
   const object = Array.isArray(activity.object)
     ? JSON.stringify(activity.object)

--- a/server/utils/outboxHelpers.ts
+++ b/server/utils/outboxHelpers.ts
@@ -1,0 +1,109 @@
+import { stringifyMarkdown } from '@nuxtjs/mdc/runtime'
+import { toHtml } from 'hast-util-to-html'
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import { unified } from 'unified'
+
+import { me, PUBLIC_AUDIENCE } from './federation'
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkRehype, { allowDangerousHtml: true })
+
+const siteOrigin = new URL(me.id).origin
+
+const CONTENT_CONTEXT = 'https://www.w3.org/ns/activitystreams'
+
+export type ContentEntry = {
+  id?: string | null
+  _id?: string | null
+  path?: string | null
+  _path?: string | null
+  body?: any
+  title?: string | null
+  stem?: string | null
+  description?: string | null
+  createdAt?: string | Date | null
+}
+
+async function renderMarkdown(markdown: string): Promise<string> {
+  if (!markdown) {
+    return ''
+  }
+  const tree = processor.parse(markdown)
+  const result = await processor.run(tree)
+  return toHtml(result, { allowDangerousHtml: true })
+}
+
+function resolveEntryPath(entry: ContentEntry): string | null {
+  const path = entry.path || entry._path || entry.id || entry._id
+  if (!path) {
+    return null
+  }
+  return path.startsWith('/') ? path : `/${path}`
+}
+
+function resolveArticleUrl(entry: ContentEntry): string | null {
+  const path = resolveEntryPath(entry)
+  if (!path) {
+    return null
+  }
+  return `${siteOrigin}${path}`
+}
+
+function normalizeDate(value?: string | Date | null): string {
+  if (!value) {
+    return new Date().toISOString()
+  }
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString()
+}
+
+export async function buildCreateActivityFromEntry(entry: ContentEntry): Promise<CreateActivity | null> {
+  const articleUrl = resolveArticleUrl(entry)
+  if (!articleUrl) {
+    return null
+  }
+
+  const markdown = entry?.body ? (await stringifyMarkdown(entry.body, {})) ?? '' : ''
+  const contentHtml = await renderMarkdown(markdown)
+  const isHtml = Boolean(contentHtml)
+  const publishedAt = normalizeDate(entry?.createdAt)
+  const title = entry?.title || entry?.stem || articleUrl
+
+  const article: ObjectT = {
+    id: articleUrl,
+    type: 'Article',
+    name: title,
+    attributedTo: me.id,
+    content: isHtml ? contentHtml : markdown,
+    mediaType: isHtml ? 'text/html' : markdown ? 'text/markdown' : undefined,
+    published: publishedAt,
+    summary: entry?.description || undefined,
+    url: articleUrl,
+    to: [PUBLIC_AUDIENCE],
+    source: markdown
+      ? {
+        content: markdown,
+        mediaType: 'text/markdown',
+      }
+      : undefined,
+  }
+
+  const activity: CreateActivity = {
+    '@context': CONTENT_CONTEXT,
+    id: `${articleUrl}#create`,
+    type: 'Create',
+    actor: me.id,
+    object: article,
+    published: publishedAt,
+    to: [PUBLIC_AUDIENCE],
+  }
+
+  return activity
+}


### PR DESCRIPTION
## Summary
- expose ActivityPub inbox, shared inbox, followers, and following collections backed by the database schema updates
- persist incoming activities and reuse a helper for generating Create activities
- add a Nitro plugin and task to broadcast new content to all followers via ActivityPub

## Testing
- yarn build *(fails: required Node >=22, container provides 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68ce55f625f88330a43e17644ec00746