### PR TITLE
Add ActivityPub content negotiation for post URLs

### DIFF
--- a/server/middleware/activitypub.ts
+++ b/server/middleware/activitypub.ts
@@ -1,0 +1,127 @@
+import { getHeader, getRequestURL } from 'h3'
+
+import { setJsonLdHeader } from '../utils/federation'
+import {
+  buildArticleObjectFromEntry,
+  buildCreateActivityFromEntry,
+  CONTENT_CONTEXT,
+} from '../utils/outboxHelpers'
+
+const ACTIVITY_SUFFIX = '/activity'
+
+const FEDERATED_PATHS: Array<{ prefix: string; collection: string }> = [
+  { prefix: '/blog', collection: 'blog' },
+  { prefix: '/app', collection: 'app' },
+]
+
+function acceptsActivityPub(acceptHeader?: string | null): boolean {
+  if (!acceptHeader) {
+    return false
+  }
+
+  const normalized = acceptHeader.toLowerCase()
+  if (normalized.includes('application/activity+json')) {
+    return true
+  }
+
+  if (normalized.includes('activity+json')) {
+    return true
+  }
+
+  if (normalized.includes('ld+json') && normalized.includes('activitystreams')) {
+    return true
+  }
+
+  if (normalized.includes('json') && normalized.includes('profile=') && normalized.includes('activitystreams')) {
+    return true
+  }
+
+  return false
+}
+
+function normalizePathname(pathname: string): string {
+  if (!pathname) {
+    return '/'
+  }
+
+  let normalized = pathname.startsWith('/') ? pathname : `/${pathname}`
+  if (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.replace(/\/+$/, '')
+    if (!normalized.startsWith('/')) {
+      normalized = `/${normalized}`
+    }
+    if (normalized.length === 0) {
+      normalized = '/'
+    }
+  }
+  return normalized || '/'
+}
+
+export default defineEventHandler(async (event) => {
+  if (event.method !== 'GET') {
+    return
+  }
+
+  const accept = getHeader(event, 'accept')
+  if (!acceptsActivityPub(accept)) {
+    return
+  }
+
+  const url = getRequestURL(event)
+  if (!url) {
+    return
+  }
+
+  let pathname = normalizePathname(url.pathname)
+  let wantsActivityResource = false
+
+  if (pathname !== '/' && pathname.endsWith(ACTIVITY_SUFFIX)) {
+    wantsActivityResource = true
+    pathname = normalizePathname(pathname.slice(0, -ACTIVITY_SUFFIX.length))
+  }
+
+  let attempted = false
+
+  for (const { prefix, collection } of FEDERATED_PATHS) {
+    if (pathname === prefix || !pathname.startsWith(`${prefix}/`)) {
+      continue
+    }
+
+    attempted = true
+
+    const entry = await queryCollection(event, collection).path(pathname).first()
+    if (!entry) {
+      continue
+    }
+
+    if (wantsActivityResource) {
+      const activity = await buildCreateActivityFromEntry(entry)
+      if (!activity) {
+        continue
+      }
+
+      setJsonLdHeader(event)
+      return activity
+    }
+
+    const article = await buildArticleObjectFromEntry(entry)
+    if (!article) {
+      continue
+    }
+
+    setJsonLdHeader(event)
+    return {
+      '@context': CONTENT_CONTEXT,
+      ...article,
+    }
+  }
+
+  if (!attempted) {
+    return
+  }
+
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'ActivityPub resource not found',
+  })
+})

--- a/server/plugins/activitypub.ts
+++ b/server/plugins/activitypub.ts
@@ -48,10 +48,11 @@ async function broadcastDocument(document: ContentEntry) {
           await db.sql`UPDATE activity
             SET activity_id = ${activity.id}, actor_id = ${actorId}, object = ${objectId}, payload = ${payload}
             WHERE activity_id = ${legacyId}`
+          return
         } catch (updateError) {
           console.error('Failed to update legacy ActivityPub identifier', updateError)
+          break
         }
-        return
       }
     }
   } catch (error) {

--- a/server/plugins/activitypub.ts
+++ b/server/plugins/activitypub.ts
@@ -1,5 +1,9 @@
 import { ensureActivitySchema } from "../utils/federation"
-import { buildCreateActivityFromEntry, type ContentEntry } from "../utils/outboxHelpers"
+import {
+  buildCreateActivityFromEntry,
+  resolveLegacyActivityIds,
+  type ContentEntry,
+} from "../utils/outboxHelpers"
 
 const FEDERATED_COLLECTIONS = new Set(['/blog/', '/app/'])
 
@@ -19,10 +23,36 @@ async function broadcastDocument(document: ContentEntry) {
 
   const db = useDatabase()
 
+  const actorId = typeof activity.actor === 'string'
+    ? activity.actor
+    : (activity.actor as { id?: string | null })?.id ?? null
+
+  const objectId = typeof activity.object === 'string'
+    ? activity.object
+    : Array.isArray(activity.object)
+      ? null
+      : (activity.object as { id?: string | null })?.id ?? null
+  const legacyActivityIds = objectId ? resolveLegacyActivityIds(objectId) : []
+
   try {
     const { rows } = await db.sql`SELECT 1 FROM activity WHERE activity_id = ${activity.id} LIMIT 1`
     if (rows && rows.length) {
       return
+    }
+
+    for (const legacyId of legacyActivityIds) {
+      const { rows: legacyRows } = await db.sql`SELECT 1 FROM activity WHERE activity_id = ${legacyId} LIMIT 1`
+      if (legacyRows && legacyRows.length) {
+        const payload = JSON.stringify(activity)
+        try {
+          await db.sql`UPDATE activity
+            SET activity_id = ${activity.id}, actor_id = ${actorId}, object = ${objectId}, payload = ${payload}
+            WHERE activity_id = ${legacyId}`
+        } catch (updateError) {
+          console.error('Failed to update legacy ActivityPub identifier', updateError)
+        }
+        return
+      }
     }
   } catch (error) {
     const message = (error as Error)?.message ?? ""

--- a/server/plugins/activitypub.ts
+++ b/server/plugins/activitypub.ts
@@ -32,7 +32,7 @@ async function broadcastDocument(document: ContentEntry) {
     : Array.isArray(activity.object)
       ? null
       : (activity.object as { id?: string | null })?.id ?? null
-  const legacyActivityIds = objectId ? resolveLegacyActivityIds(objectId) : []
+  const legacyActivityIds = objectId ? resolveLegacyActivityIds(objectId, document) : []
 
   try {
     const { rows } = await db.sql`SELECT 1 FROM activity WHERE activity_id = ${activity.id} LIMIT 1`


### PR DESCRIPTION
## Summary
- serve ActivityStreams objects for blog and app entries via middleware when ActivityPub clients request them
- refactor outbox helpers to reuse article builders, expose content negotiation constants, and publish Create activities at `/activity` URLs
- migrate legacy ActivityPub identifiers during broadcast checks to prevent duplicate deliveries

## Testing
- ⚠️ `yarn build` *(fails: project requires Node >=22 but the environment provides 20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6131b418833083f176bb84bb4398