### PR TITLE
Fix ActivityPub article content serialization

### DIFF
--- a/server/utils/outboxHelpers.ts
+++ b/server/utils/outboxHelpers.ts
@@ -1,4 +1,5 @@
 import { stringifyMarkdown } from '@nuxtjs/mdc/runtime'
+import { stringify as stringifyMinimark } from 'minimark/stringify'
 import { toHtml } from 'hast-util-to-html'
 import remarkGfm from 'remark-gfm'
 import remarkParse from 'remark-parse'
@@ -155,7 +156,15 @@ export async function buildArticleObjectFromEntry(entry: ContentEntry): Promise<
     return null
   }
 
-  const markdown = entry?.body ? (await stringifyMarkdown(entry.body, {})) ?? '' : ''
+  let markdown = ''
+  const body = entry?.body
+  if (typeof body === 'string') {
+    markdown = body
+  } else if (body?.type === 'minimark') {
+    markdown = stringifyMinimark(body) || ''
+  } else if (body) {
+    markdown = (await stringifyMarkdown(body, {})) ?? ''
+  }
   const contentHtml = await renderMarkdown(markdown)
   const isHtml = Boolean(contentHtml)
   const publishedAt = normalizeDate(entry?.createdAt)


### PR DESCRIPTION
## Summary
- ensure ActivityPub article objects convert Minimark bodies to Markdown before rendering
- fall back to existing markdown stringification for other body formats and keep original string bodies intact

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68cf70e9444083309eabb9aba56d6161