### PR TITLE
Implement follower queue and backlog delivery

### DIFF
--- a/server/routes/@me/inbox.ts
+++ b/server/routes/@me/inbox.ts
@@ -1,156 +1,35 @@
 import { me, setJsonLdHeader } from "../../utils/federation"
 
-const siteOrigin = new URL(me.id).origin
-const LOCAL_AUDIENCE_IDS = new Set<string>([me.id, me.followers].filter(Boolean) as string[])
-
-function normalizeRecipients(value: unknown): string[] {
-  if (!value) {
-    return []
-  }
-  if (Array.isArray(value)) {
-    const recipients: string[] = []
-    for (const entry of value) {
-      recipients.push(...normalizeRecipients(entry))
-    }
-    return recipients
-  }
-  if (typeof value === "string") {
-    return [value]
-  }
-  if (typeof value === "object") {
-    const candidate = value as { id?: string | null }
-    return candidate?.id ? [candidate.id] : []
-  }
-  return []
-}
-
-function targetsLocalObject(value: unknown): boolean {
-  if (!value) {
-    return false
-  }
-  if (Array.isArray(value)) {
-    return value.some((entry) => targetsLocalObject(entry))
-  }
-  if (typeof value === "string") {
-    return value === me.id || value.startsWith(siteOrigin)
-  }
-  if (typeof value === "object") {
-    const candidate = value as Record<string, any>
-    const identifier = typeof candidate.id === "string" ? candidate.id : null
-    if (identifier && (identifier === me.id || identifier.startsWith(siteOrigin))) {
-      return true
-    }
-    const inReplyTo = candidate?.inReplyTo
-    if (typeof inReplyTo === "string" && inReplyTo.startsWith(siteOrigin)) {
-      return true
-    }
-    if (candidate?.object && targetsLocalObject(candidate.object)) {
-      return true
-    }
-  }
-  return false
-}
-
-function isRelevantActivity(activity: Activity): boolean {
-  if (!activity) {
-    return false
-  }
-
-  if (targetsLocalObject(activity.object)) {
-    return true
-  }
-
-  const recipients = [
-    ...normalizeRecipients(activity.to),
-    ...normalizeRecipients((activity as any).cc),
-    ...normalizeRecipients((activity as any).bto),
-    ...normalizeRecipients((activity as any).bcc),
-    ...normalizeRecipients((activity as any).audience),
-  ]
-
-  return recipients.some((recipient) => LOCAL_AUDIENCE_IDS.has(recipient))
-}
-
-function parseStoredActivity(row: any): Activity | null {
-  if (typeof row?.payload !== "string" || !row.payload) {
-    return null
-  }
-
-  try {
-    const parsed = JSON.parse(row.payload) as Activity
-    if (!parsed || typeof parsed !== "object") {
-      return null
-    }
-
-    const normalized: Activity = { ...parsed }
-    if (!normalized.id && typeof row?.activity_id === "string" && row.activity_id) {
-      normalized.id = row.activity_id
-    }
-    return normalized
-  } catch (error) {
-    console.warn("Failed to parse stored ActivityPub payload", error)
-    return null
-  }
-}
-
-function createFallbackActivity(row: any): Activity | null {
-  const activityId = typeof row?.activity_id === "string" && row.activity_id ? row.activity_id : null
-  const actorId = typeof row?.actor_id === "string" && row.actor_id ? row.actor_id : null
-  const type = typeof row?.type === "string" && row.type ? row.type : "Activity"
-
-  if (!activityId || !actorId) {
-    return null
-  }
-
-  const fallback: Activity = {
-    "@context": "https://www.w3.org/ns/activitystreams",
-    id: activityId,
-    type: type as ActivityType,
-    actor: actorId,
-  }
-
-  if (typeof row?.object !== "undefined") {
-    fallback.object = row.object as any
-  }
-
-  return fallback
-}
-
 export default defineEventHandler(async (event) => {
   const db = useDatabase()
-  const originMatch = `${siteOrigin}/%`
-  const payloadActorMatch = `%${me.id}%`
-  const payloadOriginMatch = `%${siteOrigin}/%`
-
-  const { rows } = await db.sql`SELECT activity_id, payload, actor_id, type, object FROM activity
-    WHERE type != 'Create'
-      AND (
-        object = ${me.id}
-        OR object LIKE ${originMatch}
-        OR payload LIKE ${payloadActorMatch}
-        OR payload LIKE ${payloadOriginMatch}
-      )
-    ORDER BY created_at DESC`
+  const { rows } = await db.sql`SELECT actor_id, activity_payload FROM followers WHERE status = 'accepted' ORDER BY updated_at DESC`
 
   const orderedItems = rows?.map((row) => {
-    const parsed = parseStoredActivity(row)
-    if (parsed && isRelevantActivity(parsed)) {
-      return parsed
+    const payload = typeof row?.activity_payload === 'string' ? row.activity_payload : null
+    if (payload) {
+      try {
+        return JSON.parse(payload)
+      } catch {
+        // ignore parse errors and fall back to a minimal follow activity below
+      }
     }
-
-    const fallback = createFallbackActivity(row)
-    if (fallback && isRelevantActivity(fallback)) {
-      return fallback
+    const actorId = row?.actor_id as string | null
+    if (!actorId) {
+      return null
     }
-
-    return null
-  }).filter((activity): activity is Activity => Boolean(activity)) ?? []
+    return {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Follow',
+      actor: actorId,
+      object: me.id,
+    }
+  }).filter((value): value is Activity => Boolean(value)) ?? []
 
   setJsonLdHeader(event)
   return {
-    "@context": "https://www.w3.org/ns/activitystreams",
+    '@context': 'https://www.w3.org/ns/activitystreams',
     id: me.inbox,
-    type: "OrderedCollection",
+    type: 'OrderedCollection',
     totalItems: orderedItems.length,
     orderedItems,
   }

--- a/server/routes/@me/outbox.ts
+++ b/server/routes/@me/outbox.ts
@@ -1,26 +1,11 @@
 import { me, setJsonLdHeader } from "../../utils/federation"
-import { buildCreateActivityFromEntry } from "../../utils/outboxHelpers"
+import { collectOutboxActivities, OUTBOX_PAGE_SIZE } from "../../utils/outboxHelpers"
 
 export default defineEventHandler(async (event) => {
-  const [blogEntries, appEntries] = await Promise.all([
-    queryCollection(event, 'blog').order('createdAt', 'DESC').all(),
-    queryCollection(event, 'app').order('createdAt', 'DESC').all(),
-  ])
-
-  const entries = [...(blogEntries ?? []), ...(appEntries ?? [])]
-  entries.sort((a, b) => {
-    const aDate = a?.createdAt ? new Date(a.createdAt).getTime() : 0
-    const bDate = b?.createdAt ? new Date(b.createdAt).getTime() : 0
-    return bDate - aDate
+  const { totalItems, orderedItems } = await collectOutboxActivities(event, {
+    limit: OUTBOX_PAGE_SIZE,
+    offset: 0,
   })
-
-  const activities: CreateActivity[] = []
-  for (const entry of entries) {
-    const activity = await buildCreateActivityFromEntry(entry)
-    if (activity) {
-      activities.push(activity)
-    }
-  }
 
   setJsonLdHeader(event)
 
@@ -28,7 +13,7 @@ export default defineEventHandler(async (event) => {
     '@context': 'https://www.w3.org/ns/activitystreams',
     id: me.outbox,
     type: 'OrderedCollection',
-    totalItems: activities.length,
-    orderedItems: activities,
+    totalItems,
+    orderedItems,
   }
 })

--- a/server/tasks/ap/deliver.ts
+++ b/server/tasks/ap/deliver.ts
@@ -1,4 +1,17 @@
-import { sendActivity } from "../../utils/federation"
+import { me, sendActivity } from "../../utils/federation"
+
+function resolveActorId(actor: unknown): string | null {
+  if (!actor) {
+    return null
+  }
+  if (typeof actor === 'string') {
+    return actor
+  }
+  if (typeof actor === 'object' && typeof (actor as Actor | null)?.id === 'string') {
+    return (actor as Actor).id
+  }
+  return null
+}
 
 type DeliverPayload = {
   activity: Activity
@@ -25,9 +38,9 @@ export default defineTask({
       recipients.add(target)
     }
 
-    const actorId = typeof activity.actor === 'string' ? activity.actor : activity.actor?.id
-    if (!recipients.size && actorId) {
-      const { rows } = await db.sql`SELECT actor_id FROM activity WHERE object = ${actorId} AND type = 'Follow'`
+    const actorId = resolveActorId(activity?.actor)
+    if (!recipients.size && actorId === me.id) {
+      const { rows } = await db.sql`SELECT actor_id FROM followers WHERE status = 'accepted'`
       for (const row of rows ?? []) {
         const follower = row.actor_id as string | null
         if (follower) {

--- a/server/tasks/ap/sendActivity.ts
+++ b/server/tasks/ap/sendActivity.ts
@@ -1,8 +1,36 @@
-import { sendActivity } from "../../utils/federation"
+import { randomUUID } from "node:crypto"
+
+import { me, sendActivity } from "../../utils/federation"
 
 type Payload = {
   activity: Activity
   target?: string | string[]
+}
+
+function resolveActorId(actor: unknown): string | null {
+  if (!actor) {
+    return null
+  }
+  if (typeof actor === 'string') {
+    return actor
+  }
+  if (typeof actor === 'object' && typeof (actor as Actor | null)?.id === 'string') {
+    return (actor as Actor).id
+  }
+  return null
+}
+
+function resolveObjectId(object: unknown): string | null {
+  if (!object) {
+    return null
+  }
+  if (typeof object === 'string') {
+    return object
+  }
+  if (typeof object === 'object' && typeof (object as { id?: string | null })?.id === 'string') {
+    return (object as { id: string }).id
+  }
+  return null
 }
 export default defineTask({
   meta: {
@@ -24,9 +52,31 @@ export default defineTask({
       recipients.add(target)
     }
 
-    const actorId = typeof activity.actor === 'string' ? activity.actor : activity.actor?.id
-    if (!recipients.size && actorId) {
-      const { rows } = await db.sql`SELECT actor_id FROM activity WHERE object = ${actorId} AND type = 'Follow'`
+    const actorId = resolveActorId(activity?.actor)
+
+    if (activity?.type === 'Follow' && actorId === me.id) {
+      const followTarget = resolveObjectId(activity.object)
+      if (followTarget) {
+        const followId = typeof activity.id === 'string' && activity.id ? activity.id : randomUUID()
+        const payload = JSON.stringify({
+          '@context': activity['@context'] ?? 'https://www.w3.org/ns/activitystreams',
+          id: followId,
+          type: 'Follow',
+          actor: me.id,
+          object: followTarget,
+        })
+        await db.sql`INSERT INTO following (actor_id, activity_id, activity_payload, status)
+          VALUES (${followTarget}, ${followId}, ${payload}, 'requested')
+          ON CONFLICT(actor_id) DO UPDATE SET
+            activity_id = excluded.activity_id,
+            activity_payload = excluded.activity_payload,
+            status = 'requested',
+            updated_at = CURRENT_TIMESTAMP`
+      }
+    }
+
+    if (!recipients.size && actorId === me.id) {
+      const { rows } = await db.sql`SELECT actor_id FROM followers WHERE status = 'accepted'`
       for (const row of rows ?? []) {
         const follower = row.actor_id as string | null
         if (follower) {

--- a/server/tasks/db/seed.ts
+++ b/server/tasks/db/seed.ts
@@ -8,19 +8,58 @@ export default defineTask({
   async run(event) {
     const db = useDatabase()
 
-    // Create the database and tables
+    // Drop existing tables so we can recreate them with the latest schema
+    await db.sql`DROP TABLE IF EXISTS activity;`
+    await db.sql`DROP TABLE IF EXISTS followers;`
+    await db.sql`DROP TABLE IF EXISTS following;`
+    await db.sql`DROP TABLE IF EXISTS actor;`
+
+    // Activity queue table for inbound/outbound ActivityPub messages
     await db.sql`CREATE TABLE IF NOT EXISTS activity (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      activity_id TEXT,
+      activity_id TEXT NOT NULL,
       actor_id TEXT,
       type TEXT,
       object TEXT,
       payload TEXT,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      direction TEXT NOT NULL DEFAULT 'inbox',
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
     );`
     await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_activity_activity_id ON activity(activity_id);`
-    await db.sql`CREATE INDEX IF NOT EXISTS ix_activity_actor_id_type ON activity(actor_id, type);`
-    console.info('Created activity table and index')
+    await db.sql`CREATE INDEX IF NOT EXISTS ix_activity_direction_type ON activity(direction, type);`
+    await db.sql`CREATE INDEX IF NOT EXISTS ix_activity_actor_direction ON activity(actor_id, direction);`
+    console.info('Created activity table and indexes')
+
+    // Followers table to track remote actors following the local account
+    await db.sql`CREATE TABLE IF NOT EXISTS followers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      actor_id TEXT NOT NULL,
+      activity_id TEXT,
+      activity_payload TEXT,
+      status TEXT NOT NULL DEFAULT 'accepted',
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );`
+    await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_followers_actor_id ON followers(actor_id);`
+    await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_followers_activity_id ON followers(activity_id) WHERE activity_id IS NOT NULL;`
+    await db.sql`CREATE INDEX IF NOT EXISTS ix_followers_status ON followers(status);`
+    console.info('Created followers table and indexes')
+
+    // Following table to track remote actors followed by the local account
+    await db.sql`CREATE TABLE IF NOT EXISTS following (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      actor_id TEXT NOT NULL,
+      activity_id TEXT,
+      activity_payload TEXT,
+      status TEXT NOT NULL DEFAULT 'requested',
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );`
+    await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_following_actor_id ON following(actor_id);`
+    await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_following_activity_id ON following(activity_id) WHERE activity_id IS NOT NULL;`
+    await db.sql`CREATE INDEX IF NOT EXISTS ix_following_status ON following(status);`
+    console.info('Created following table and indexes')
 
     await db.sql`CREATE TABLE IF NOT EXISTS actor (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/server/utils/inbox.ts
+++ b/server/utils/inbox.ts
@@ -1,47 +1,215 @@
 import { randomUUID } from 'node:crypto'
 import type { H3Event } from 'h3'
 
-import { acceptFollowRequest, ensureActivitySchema, setJsonLdHeader } from './federation'
+import { acceptFollowRequest, me, removeFollower, setJsonLdHeader } from './federation'
+import { verifySignature } from './auth'
 
-async function recordActivity(activity: Activity): Promise<void> {
+function normalizeActorId(actor: unknown): string | null {
+  if (!actor) {
+    return null
+  }
+  if (typeof actor === 'string') {
+    return actor
+  }
+  if (typeof actor === 'object' && typeof (actor as Actor | null)?.id === 'string') {
+    return (actor as Actor).id
+  }
+  return null
+}
+
+function normalizeObjectIdentifier(object: unknown): string | null {
+  if (!object) {
+    return null
+  }
+  if (typeof object === 'string') {
+    return object
+  }
+  if (Array.isArray(object)) {
+    for (const entry of object) {
+      const candidate = normalizeObjectIdentifier(entry)
+      if (candidate) {
+        return candidate
+      }
+    }
+    return null
+  }
+  if (typeof object === 'object' && typeof (object as { id?: string | null })?.id === 'string') {
+    return (object as { id: string }).id
+  }
+  return null
+}
+
+async function recordActivity(activity: Activity): Promise<string> {
   const db = useDatabase()
   const activityId = typeof activity.id === 'string' && activity.id
     ? activity.id
     : randomUUID()
-  const actorId = typeof activity.actor === 'string' ? activity.actor : activity.actor?.id
-  const object = Array.isArray(activity.object)
-    ? JSON.stringify(activity.object)
-    : typeof activity.object === 'string'
-      ? activity.object
-      : activity.object && typeof activity.object === 'object'
-        ? activity.object.id || JSON.stringify(activity.object)
+  const actorId = normalizeActorId(activity.actor)
+  const objectValue = activity.object
+  const object = Array.isArray(objectValue)
+    ? JSON.stringify(objectValue)
+    : typeof objectValue === 'string'
+      ? objectValue
+      : objectValue && typeof objectValue === 'object'
+        ? (objectValue as { id?: string | null }).id ?? JSON.stringify(objectValue)
         : null
   const payload = JSON.stringify(activity)
 
-  const insertActivity = () => db.sql`INSERT INTO activity (activity_id, actor_id, type, object, payload) VALUES (
-    ${activityId}, ${actorId}, ${activity.type}, ${object}, ${payload}
-  )`
+  await db.sql`INSERT INTO activity (activity_id, actor_id, type, object, payload, direction)
+    VALUES (${activityId}, ${actorId}, ${activity.type}, ${object}, ${payload}, 'inbox')
+    ON CONFLICT(activity_id) DO UPDATE SET
+      actor_id = excluded.actor_id,
+      type = excluded.type,
+      object = excluded.object,
+      payload = excluded.payload,
+      direction = excluded.direction,
+      updated_at = CURRENT_TIMESTAMP`
 
-  try {
-    await insertActivity()
-  } catch (error) {
-    const message = (error as Error)?.message ?? ''
-    if (/no such table: activity/i.test(message)) {
-      await ensureActivitySchema(db)
-      await insertActivity()
-      return
-    }
-    if (/no column named (activity_id|payload)/i.test(message)) {
-      await ensureActivitySchema(db)
-      await insertActivity()
-      return
-    }
-    if (/unique constraint failed|duplicate/i.test(message)) {
-      return
-    }
-    console.error('Failed recording ActivityPub inbox activity', error)
-    throw error
+  return activityId
+}
+
+async function deleteRecordedActivity(activityId: string | null | undefined): Promise<void> {
+  if (!activityId) {
+    return
   }
+  const db = useDatabase()
+  await db.sql`DELETE FROM activity WHERE activity_id = ${activityId} AND direction = 'inbox'`
+}
+
+async function handleUndoActivity(event: H3Event, activity: UndoActivity) {
+  const actorId = normalizeActorId(activity.actor)
+  if (!actorId) {
+    return sendError(event, createError({ statusCode: 400, statusMessage: 'Undo activity missing actor' }))
+  }
+
+  if (!await verifySignature(event, actorId)) {
+    return
+  }
+
+  const objectValue = activity.object as unknown
+  let followActivityId: string | null = null
+  let followActorId: string | null = null
+  let followTarget: string | null = null
+  let followType: string | null = null
+
+  if (typeof objectValue === 'string') {
+    followActivityId = objectValue
+  } else if (objectValue && typeof objectValue === 'object') {
+    const followObject = objectValue as Partial<FollowActivity> & { type?: string }
+    followActivityId = typeof followObject.id === 'string' ? followObject.id : null
+    followActorId = normalizeActorId(followObject.actor as unknown)
+    followTarget = normalizeObjectIdentifier(followObject.object as unknown)
+    followType = typeof followObject.type === 'string' ? followObject.type : null
+  }
+
+  if (followType && followType !== 'Follow') {
+    return
+  }
+
+  if (!followActorId) {
+    followActorId = actorId
+  }
+
+  if (followActorId !== actorId) {
+    return
+  }
+
+  if (followTarget && followTarget !== me.id && followTarget !== me.followers) {
+    return
+  }
+
+  await removeFollower(actorId, followActivityId)
+  setJsonLdHeader(event)
+  setResponseStatus(event, 202)
+  return { status: 'Accepted' }
+}
+
+async function handleAcceptActivity(event: H3Event, activity: AcceptActivity) {
+  const actorId = normalizeActorId(activity.actor)
+  if (!actorId) {
+    return sendError(event, createError({ statusCode: 400, statusMessage: 'Accept activity missing actor' }))
+  }
+
+  if (!await verifySignature(event, actorId)) {
+    return
+  }
+
+  const db = useDatabase()
+  const objectValue = activity.object as unknown
+  let followActivityId: string | null = null
+  let followActorId: string | null = null
+  let followTargetId: string | null = null
+  let followPayload: string | null = null
+
+  if (typeof objectValue === 'string') {
+    followActivityId = objectValue
+  } else if (objectValue && typeof objectValue === 'object') {
+    const followObject = objectValue as Partial<FollowActivity>
+    followActivityId = typeof followObject.id === 'string' ? followObject.id : null
+    followActorId = normalizeActorId(followObject.actor as unknown)
+    followTargetId = normalizeObjectIdentifier(followObject.object as unknown)
+
+    const normalizedFollow: FollowActivity = {
+      '@context': followObject['@context'] ?? 'https://www.w3.org/ns/activitystreams',
+      id: followActivityId ?? randomUUID(),
+      type: 'Follow',
+      actor: me.id,
+      object: followTargetId ?? actorId,
+    }
+    followActivityId = normalizedFollow.id
+    followTargetId = normalizedFollow.object
+    followPayload = JSON.stringify(normalizedFollow)
+  }
+
+  if (followActorId && followActorId !== me.id) {
+    return
+  }
+
+  const targetActorId = followTargetId ?? actorId
+  let payloadToStore = followPayload
+  let activityIdentifier = followActivityId ?? null
+
+  if (targetActorId) {
+    const { rows } = await db.sql`SELECT activity_id, activity_payload FROM following WHERE actor_id = ${targetActorId} LIMIT 1`
+    const existing = rows?.[0] as { activity_id?: string | null; activity_payload?: string | null } | undefined
+
+    if (!activityIdentifier && existing?.activity_id) {
+      activityIdentifier = existing.activity_id ?? null
+    }
+    if (!payloadToStore && typeof existing?.activity_payload === 'string' && existing.activity_payload) {
+      payloadToStore = existing.activity_payload
+    }
+
+    if (!payloadToStore) {
+      const fallback: FollowActivity = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: activityIdentifier ?? randomUUID(),
+        type: 'Follow',
+        actor: me.id,
+        object: targetActorId,
+      }
+      payloadToStore = JSON.stringify(fallback)
+      activityIdentifier = fallback.id
+    }
+
+    await db.sql`INSERT INTO following (actor_id, activity_id, activity_payload, status)
+      VALUES (${targetActorId}, ${activityIdentifier}, ${payloadToStore}, 'accepted')
+      ON CONFLICT(actor_id) DO UPDATE SET
+        activity_id = COALESCE(excluded.activity_id, following.activity_id),
+        activity_payload = COALESCE(excluded.activity_payload, following.activity_payload),
+        status = 'accepted',
+        updated_at = CURRENT_TIMESTAMP`
+  }
+
+  setJsonLdHeader(event)
+  setResponseStatus(event, 202)
+  return { status: 'Accepted' }
+}
+
+async function handleDefaultActivity(event: H3Event) {
+  setJsonLdHeader(event)
+  setResponseStatus(event, 202)
+  return { status: 'Accepted' }
 }
 
 export async function handleInboxPost(event: H3Event) {
@@ -56,13 +224,45 @@ export async function handleInboxPost(event: H3Event) {
     return sendError(event, createError({ statusCode: 400, statusMessage: 'Failed to parse request body' }))
   }
 
-  switch (activity.type) {
-    case 'Follow':
-      return await acceptFollowRequest(event, activity as FollowActivity)
-    default:
-      await recordActivity(activity)
-      setJsonLdHeader(event)
-      setResponseStatus(event, 202)
-      return { status: 'Accepted' }
+  let recordedActivityId: string | null = null
+  try {
+    recordedActivityId = await recordActivity(activity)
+  } catch (error) {
+    console.error('Failed storing ActivityPub inbox activity', error)
+    return sendError(event, createError({ statusCode: 500, statusMessage: 'Failed to persist inbox activity' }))
+  }
+
+  let processed = false
+  try {
+    switch (activity.type) {
+      case 'Follow': {
+        const response = await acceptFollowRequest(event, activity as FollowActivity)
+        processed = true
+        return response
+      }
+      case 'Undo': {
+        const response = await handleUndoActivity(event, activity as UndoActivity)
+        processed = true
+        return response
+      }
+      case 'Accept': {
+        const response = await handleAcceptActivity(event, activity as AcceptActivity)
+        processed = true
+        return response
+      }
+      default: {
+        const response = await handleDefaultActivity(event)
+        processed = true
+        return response
+      }
+    }
+  } finally {
+    if (processed && recordedActivityId) {
+      try {
+        await deleteRecordedActivity(recordedActivityId)
+      } catch (cleanupError) {
+        console.error('Failed removing processed inbox activity', cleanupError)
+      }
+    }
   }
 }

--- a/server/utils/types.d.ts
+++ b/server/utils/types.d.ts
@@ -92,6 +92,11 @@ type AcceptActivity = Omit<Activity, 'type' | 'object'> & {
   object: Activity | ObjectT | string
 }
 
+interface UndoActivity extends Activity {
+  type: 'Undo'
+  object: Activity | ObjectT | string
+}
+
 interface FollowActivity extends Activity {
   type: 'Follow'
   actor: string


### PR DESCRIPTION
## Summary
- replace ad-hoc activity storage with dedicated followers/following tables and expand the inbox activity queue schema
- process inbox activities by enqueuing, handling Follow/Accept/Undo, updating followers/following records, and removing processed entries
- send Accept replies plus the first outbox page to new followers and update ActivityPub routes/tasks to rely on the new tables

## Testing
- attempted to run `npx nuxt task db:seed` *(command not available in installed Nuxt CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d115f59c83309aaf8ad76812f6c9