### PR TITLE
Add host-meta endpoint and expand WebFinger aliases

### DIFF
--- a/server/routes/.well-known/host-meta.ts
+++ b/server/routes/.well-known/host-meta.ts
@@ -1,0 +1,12 @@
+const DOMAIN = 'changkyun.kim'
+
+const HOST_META_RESPONSE = `<?xml version="1.0" encoding="UTF-8"?>
+<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+  <Link rel="lrdd" type="application/xrd+xml" template="https://${DOMAIN}/.well-known/webfinger?resource={uri}" />
+  <Link rel="lrdd" type="application/jrd+json" template="https://${DOMAIN}/.well-known/webfinger?resource={uri}" />
+</XRD>`
+
+export default defineEventHandler((event) => {
+  setResponseHeader(event, 'Content-Type', 'application/xrd+xml; charset=utf-8')
+  return HOST_META_RESPONSE
+})

--- a/server/routes/.well-known/webfinger.ts
+++ b/server/routes/.well-known/webfinger.ts
@@ -1,15 +1,27 @@
-export default defineEventHandler(async (event) => {
-  const { resource } = getQuery<{ resource: string }>(event)
+import { me } from '~/server/utils/federation'
+
+const DOMAIN = 'changkyun.kim'
+const ACTOR_HANDLE = 'me'
+
+const VALID_RESOURCES = new Set([
+  `acct:${ACTOR_HANDLE}@${DOMAIN}`,
+  `acct:${me.preferredUsername.toLowerCase()}@${DOMAIN}`,
+])
+
+export default defineEventHandler((event) => {
+  const { resource } = getQuery<{ resource?: string }>(event)
 
   if (!resource) {
-    return createError({
+    throw createError({
       statusCode: 400,
       statusMessage: 'Missing resource parameter',
     })
   }
 
-  if (resource !== 'acct:me@changkyun.kim') {
-    return createError({
+  const normalizedResource = resource.toLowerCase()
+
+  if (!VALID_RESOURCES.has(normalizedResource)) {
+    throw createError({
       statusCode: 404,
       statusMessage: 'Resource not found',
     })
@@ -17,13 +29,13 @@ export default defineEventHandler(async (event) => {
 
   setResponseHeader(event, 'Content-Type', 'application/jrd+json')
   return {
-    subject: resource,
+    subject: normalizedResource,
     aliases: ['https://changkyun.kim/@me'],
     links: [
       {
         rel: 'self',
         type: 'application/activity+json',
-        href: 'https://changkyun.kim/@me',
+        href: me.id,
       },
       {
         rel: 'https://webfinger.net/rel/profile-page',


### PR DESCRIPTION
## Summary
- add a `.well-known/host-meta` endpoint that points ActivityPub clients to the WebFinger template
- allow the WebFinger handler to recognise both `me@changkyun.kim` and `changkyun.kim@changkyun.kim`

## Testing
- yarn build *(fails: Node >=22 is required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d10d18432c83309e05f56291f97bc2