### PR TITLE
Fix ActivityPub handle canonicalization and backlog delivery

### DIFF
--- a/server/routes/.well-known/webfinger.ts
+++ b/server/routes/.well-known/webfinger.ts
@@ -2,11 +2,16 @@ import { me } from '../../utils/federation'
 
 const DOMAIN = 'changkyun.kim'
 const ACTOR_HANDLE = 'me'
+const CANONICAL_SUBJECT = `acct:${ACTOR_HANDLE}@${DOMAIN}`
+const LEGACY_RESOURCES = [`acct:changkyun.kim@${DOMAIN}`]
 
-const VALID_RESOURCES = new Set([
-  `acct:${ACTOR_HANDLE}@${DOMAIN}`,
-  `acct:${me.preferredUsername.toLowerCase()}@${DOMAIN}`,
-])
+const VALID_RESOURCES = new Set(
+  [
+    CANONICAL_SUBJECT,
+    `acct:${me.preferredUsername.toLowerCase()}@${DOMAIN}`,
+    ...LEGACY_RESOURCES,
+  ].map((value) => value.toLowerCase()),
+)
 
 export default defineEventHandler((event) => {
   const { resource } = getQuery<{ resource?: string }>(event)
@@ -29,8 +34,11 @@ export default defineEventHandler((event) => {
 
   setResponseHeader(event, 'Content-Type', 'application/jrd+json')
   return {
-    subject: normalizedResource,
-    aliases: ['https://changkyun.kim/@me'],
+    subject: CANONICAL_SUBJECT,
+    aliases: [
+      'https://changkyun.kim/@me',
+      ...LEGACY_RESOURCES,
+    ],
     links: [
       {
         rel: 'self',

--- a/server/tasks/ap/deliverBacklog.ts
+++ b/server/tasks/ap/deliverBacklog.ts
@@ -1,0 +1,123 @@
+import { sendActivity } from "../../utils/federation"
+
+const DEFAULT_INITIAL_DELAY_MS = 1500
+const BETWEEN_DELIVERY_DELAY_MS = 800
+const RETRY_DELAY_MS = 3000
+const MAX_RETRIES = 3
+
+type DeliverBacklogPayload = {
+  activities?: CreateActivity[]
+  target?: string | string[]
+  initialDelay?: number
+}
+
+type DeliveryFailure = {
+  activityId: string | null
+  actor: string
+  message: string
+  attempts: number
+}
+
+function isCreateActivity(value: any): value is CreateActivity {
+  return value && typeof value === 'object' && value.type === 'Create'
+}
+
+function normalizeTarget(target: string | string[] | undefined): string | null {
+  if (!target) {
+    return null
+  }
+  if (Array.isArray(target)) {
+    for (const entry of target) {
+      if (typeof entry === 'string' && entry) {
+        return entry
+      }
+    }
+    return null
+  }
+  return typeof target === 'string' && target ? target : null
+}
+
+function resolveDelay(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback
+  }
+  return Math.max(0, Math.trunc(value))
+}
+
+function wait(ms: number): Promise<void> {
+  if (!ms) {
+    return Promise.resolve()
+  }
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export default defineTask({
+  meta: {
+    name: 'ap:deliverBacklog',
+    description: 'Deliver Create activities backlog to a newly-accepted follower',
+  },
+  async run(event) {
+    const { activities, target, initialDelay } = event.payload as DeliverBacklogPayload
+
+    const normalizedTarget = normalizeTarget(target)
+    const backlog = Array.isArray(activities) ? activities.filter(isCreateActivity) : []
+
+    if (!normalizedTarget || backlog.length === 0) {
+      return { result: false, reason: 'invalid-payload' }
+    }
+
+    const initialWait = resolveDelay(initialDelay, DEFAULT_INITIAL_DELAY_MS)
+    if (initialWait > 0) {
+      await wait(initialWait)
+    }
+
+    let delivered = 0
+    const failures: DeliveryFailure[] = []
+
+    for (let index = 0; index < backlog.length; index += 1) {
+      const activity = backlog[index]
+      const activityId = typeof activity?.id === 'string' ? activity.id : null
+      let attempt = 0
+      let success = false
+      let lastError: Error | null = null
+
+      while (attempt < MAX_RETRIES && !success) {
+        attempt += 1
+        try {
+          await sendActivity(activity, normalizedTarget)
+          success = true
+          delivered += 1
+        } catch (error) {
+          lastError = error instanceof Error ? error : new Error(String(error))
+          if (attempt < MAX_RETRIES) {
+            await wait(RETRY_DELAY_MS)
+          }
+        }
+      }
+
+      if (!success) {
+        failures.push({
+          activityId,
+          actor: normalizedTarget,
+          message: lastError?.message ?? 'Unknown delivery failure',
+          attempts: attempt,
+        })
+      }
+
+      if (index < backlog.length - 1 && BETWEEN_DELIVERY_DELAY_MS > 0) {
+        await wait(BETWEEN_DELIVERY_DELAY_MS)
+      }
+    }
+
+    if (failures.length) {
+      console.warn('Backlog delivery completed with failures', failures)
+    }
+
+    return {
+      result: true,
+      delivered,
+      failed: failures,
+      total: backlog.length,
+    }
+  },
+})


### PR DESCRIPTION
## Summary
- return a canonical `acct:me@changkyun.kim` subject from WebFinger while keeping the legacy handle as an alias
- change the local actor profile to use the `me` preferred username and schedule backlog deliveries through a dedicated task with a grace period
- generate ActivityPub article objects on the changkyun.kim domain while exposing public/legacy URLs and deliver backlog items with retries and pacing delays

## Testing
- `yarn build` *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*

------
https://chatgpt.com/codex/tasks/task_e_68d11628306c8330bb2c1785304973d1