### PR TITLE
Handle content negotiation on @me route

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,16 @@
     "@popperjs/core": "^2.11.6",
     "@tailwindcss/typography": "^0.5.16",
     "better-sqlite3": "^12.2.0",
+    "negotiator": "^1.0.0",
     "nuxt": "^4.1.2"
   },
   "devDependencies": {
-    "sharp": "^0.34.3",
     "@nuxthub/core": "0.9.0",
     "@types/glob": "^8.0.0",
+    "@types/negotiator": "^0.6.4",
     "@types/sharp": "^0.32.0",
     "glob": "^11.0.1",
+    "sharp": "^0.34.3",
     "wrangler": "^4.29.1"
   },
   "resolutions": {

--- a/server/routes/@me/index.ts
+++ b/server/routes/@me/index.ts
@@ -1,112 +1,60 @@
+import Negotiator from 'negotiator'
 import { getHeader, sendRedirect } from 'h3'
 
 import { me, setJsonLdHeader } from '../../utils/federation'
 
 const HTML_MEDIA_TYPES = new Set(['text/html', 'application/xhtml+xml'])
+const ACTIVITY_MEDIA_TYPES = new Set(['application/activity+json', 'application/ld+json', 'application/json'])
 
-type ParsedMediaType = {
-  value: string
-  q: number
-  params: Record<string, string>
+function isHtmlMediaType(mediaType: string): boolean {
+  return HTML_MEDIA_TYPES.has(mediaType) || mediaType === 'text/*'
 }
 
-function parseAcceptHeader(accept?: string | null): ParsedMediaType[] {
-  if (!accept) {
-    return []
+function isActivityMediaType(mediaType: string): boolean {
+  if (ACTIVITY_MEDIA_TYPES.has(mediaType) || mediaType === 'application/*') {
+    return true
   }
 
-  return accept
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .map((entry) => {
-      const [valuePart, ...paramParts] = entry.split(';')
-      const value = valuePart.trim().toLowerCase()
-      const params: Record<string, string> = {}
-      let q = 1
-
-      for (const part of paramParts) {
-        const [rawKey, ...rawValueParts] = part.split('=')
-        if (!rawKey) {
-          continue
-        }
-
-        const key = rawKey.trim().toLowerCase()
-        let paramValue = rawValueParts.join('=').trim()
-        if (paramValue.startsWith('"') && paramValue.endsWith('"')) {
-          paramValue = paramValue.slice(1, -1)
-        }
-
-        if (key === 'q') {
-          const parsed = Number.parseFloat(paramValue)
-          if (!Number.isNaN(parsed)) {
-            q = parsed
-          }
-        }
-
-        if (paramValue.length > 0) {
-          params[key] = paramValue.toLowerCase()
-        }
-      }
-
-      return { value, q, params }
-    })
-}
-
-function getMaxWeight(entries: ParsedMediaType[], predicate: (entry: ParsedMediaType) => boolean): number {
-  let weight = 0
-  for (const entry of entries) {
-    if (entry.q <= 0) {
-      continue
-    }
-    if (!predicate(entry)) {
-      continue
-    }
-    if (entry.q > weight) {
-      weight = entry.q
-    }
-  }
-  return weight
-}
-
-function isHtmlMediaType(entry: ParsedMediaType): boolean {
-  return HTML_MEDIA_TYPES.has(entry.value)
-}
-
-function isActivityMediaType(entry: ParsedMediaType): boolean {
-  if (!entry.value.includes('json')) {
+  const separatorIndex = mediaType.indexOf('/')
+  if (separatorIndex === -1) {
     return false
   }
 
-  if (entry.value === 'application/activity+json') {
-    return true
-  }
-
-  if (entry.value.endsWith('activity+json')) {
-    return true
-  }
-
-  const profile = entry.params.profile
-  return typeof profile === 'string' && profile.includes('activitystreams')
+  const subtype = mediaType.slice(separatorIndex + 1)
+  return subtype === 'json' || subtype.endsWith('+json')
 }
 
 function prefersHtml(accept?: string | null): boolean {
-  const entries = parseAcceptHeader(accept)
-  if (!entries.length) {
+  if (!accept) {
     return false
   }
 
-  const htmlWeight = getMaxWeight(entries, isHtmlMediaType)
-  if (htmlWeight <= 0) {
+  const negotiator = new Negotiator({ headers: { accept } })
+  const acceptedMediaTypes = negotiator.mediaTypes()
+
+  if (!acceptedMediaTypes.length) {
     return false
   }
 
-  const activityWeight = getMaxWeight(entries, isActivityMediaType)
-  if (activityWeight <= 0) {
-    return true
+  let activitySeen = false
+
+  for (const mediaType of acceptedMediaTypes) {
+    const normalized = mediaType.toLowerCase()
+
+    if (normalized === '*/*') {
+      continue
+    }
+
+    if (isHtmlMediaType(normalized)) {
+      return !activitySeen
+    }
+
+    if (isActivityMediaType(normalized)) {
+      activitySeen = true
+    }
   }
 
-  return htmlWeight > activityWeight
+  return false
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/routes/@me/index.ts
+++ b/server/routes/@me/index.ts
@@ -1,5 +1,120 @@
+import { getHeader, sendRedirect } from 'h3'
+
+import { me, setJsonLdHeader } from '../../utils/federation'
+
+const HTML_MEDIA_TYPES = new Set(['text/html', 'application/xhtml+xml'])
+
+type ParsedMediaType = {
+  value: string
+  q: number
+  params: Record<string, string>
+}
+
+function parseAcceptHeader(accept?: string | null): ParsedMediaType[] {
+  if (!accept) {
+    return []
+  }
+
+  return accept
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [valuePart, ...paramParts] = entry.split(';')
+      const value = valuePart.trim().toLowerCase()
+      const params: Record<string, string> = {}
+      let q = 1
+
+      for (const part of paramParts) {
+        const [rawKey, ...rawValueParts] = part.split('=')
+        if (!rawKey) {
+          continue
+        }
+
+        const key = rawKey.trim().toLowerCase()
+        let paramValue = rawValueParts.join('=').trim()
+        if (paramValue.startsWith('"') && paramValue.endsWith('"')) {
+          paramValue = paramValue.slice(1, -1)
+        }
+
+        if (key === 'q') {
+          const parsed = Number.parseFloat(paramValue)
+          if (!Number.isNaN(parsed)) {
+            q = parsed
+          }
+        }
+
+        if (paramValue.length > 0) {
+          params[key] = paramValue.toLowerCase()
+        }
+      }
+
+      return { value, q, params }
+    })
+}
+
+function getMaxWeight(entries: ParsedMediaType[], predicate: (entry: ParsedMediaType) => boolean): number {
+  let weight = 0
+  for (const entry of entries) {
+    if (entry.q <= 0) {
+      continue
+    }
+    if (!predicate(entry)) {
+      continue
+    }
+    if (entry.q > weight) {
+      weight = entry.q
+    }
+  }
+  return weight
+}
+
+function isHtmlMediaType(entry: ParsedMediaType): boolean {
+  return HTML_MEDIA_TYPES.has(entry.value)
+}
+
+function isActivityMediaType(entry: ParsedMediaType): boolean {
+  if (!entry.value.includes('json')) {
+    return false
+  }
+
+  if (entry.value === 'application/activity+json') {
+    return true
+  }
+
+  if (entry.value.endsWith('activity+json')) {
+    return true
+  }
+
+  const profile = entry.params.profile
+  return typeof profile === 'string' && profile.includes('activitystreams')
+}
+
+function prefersHtml(accept?: string | null): boolean {
+  const entries = parseAcceptHeader(accept)
+  if (!entries.length) {
+    return false
+  }
+
+  const htmlWeight = getMaxWeight(entries, isHtmlMediaType)
+  if (htmlWeight <= 0) {
+    return false
+  }
+
+  const activityWeight = getMaxWeight(entries, isActivityMediaType)
+  if (activityWeight <= 0) {
+    return true
+  }
+
+  return htmlWeight > activityWeight
+}
+
 export default defineEventHandler(async (event) => {
-  // TODO: check accept header
+  const accept = getHeader(event, 'accept')
+  if (prefersHtml(accept)) {
+    return sendRedirect(event, '/about')
+  }
+
   const db = useDatabase()
   const { rows } = await db.sql`SELECT * FROM actor WHERE actor_id = ${me.id}`
   let publicKey: PublicKey | undefined = undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,6 +2307,11 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
+"@types/negotiator@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@types/negotiator/-/negotiator-0.6.4.tgz#d2c0e186cfe1ce2ba38818acce756284ca4d8642"
+  integrity sha512-elf6BsTq+AkyNsb2h5cGNst2Mc7dPliVoAPm1fXglC/BM3f2pFA40BaSSv3E5lyHteEawVKLP+8TwiY1DMNb3A==
+
 "@types/node@*":
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-24.3.0.tgz#89b09f45cb9a8ee69466f18ee5864e4c3eb84dec"
@@ -5890,6 +5895,11 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+negotiator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
+  integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
+
 nitro-cloudflare-dev@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/nitro-cloudflare-dev/-/nitro-cloudflare-dev-0.2.2.tgz#d9e88977f3b54eaca273ba63c67bf9473f98075c"
@@ -7664,16 +7674,7 @@ streamx@^2.15.0, streamx@^2.21.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7713,14 +7714,7 @@ stringify-entities@^4.0.0, stringify-entities@^4.0.4:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8607,16 +8601,7 @@ wrangler@^4.29.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Summary
- parse the Accept header on the /@me route to distinguish between ActivityPub and HTML clients
- redirect browsers that prefer HTML to the /about page while preserving the JSON-LD actor response for ActivityPub requests
- keep the ActivityPub response untouched when HTML is not explicitly preferred

## Testing
- yarn build *(fails: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.19.4")*

------
https://chatgpt.com/codex/tasks/task_e_68d11bde1eb083309a174167f55f0f2e