### PR TITLE
fix: normalize blog content paths for trailing slash redirects

### DIFF
--- a/app/composables/normalizeRoutePath.ts
+++ b/app/composables/normalizeRoutePath.ts
@@ -1,0 +1,12 @@
+export function normalizeRoutePath(path?: string | null) {
+  if (!path) {
+    return '/'
+  }
+
+  const normalized = path.startsWith('/') ? path : `/${path}`
+  if (normalized.length === 1) {
+    return normalized
+  }
+
+  return normalized.replace(/\/+$/, '') || '/'
+}

--- a/app/pages/app/[...path].vue
+++ b/app/pages/app/[...path].vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
+import { normalizeRoutePath } from '~/composables/normalizeRoutePath'
+
 const route = useRoute()
+const contentPath = computed(() => normalizeRoutePath(route.path))
 
 const { data, error } = await useAsyncData(
-  () => `app-entry:${route.fullPath}`,
-  () => queryCollection('app').path(route.path).first(),
-  {
-    watch: [() => route.fullPath],
-  },
+  () => `app-entry:${contentPath.value}`,
+  () => queryCollection('app').path(contentPath.value).first(),
 )
 
 const coverImage = computed(() => data.value?.coverImage)

--- a/app/pages/blog/[...path].vue
+++ b/app/pages/blog/[...path].vue
@@ -1,22 +1,21 @@
 <script setup lang="ts">
+import { normalizeRoutePath } from '~/composables/normalizeRoutePath'
+
 const route = useRoute()
+const contentPath = computed(() => normalizeRoutePath(route.path))
 
 const { data } = await useAsyncData(
-  () => `blog-entry:${route.fullPath}`,
-  () => queryCollection('blog').path(route.path).first(),
-  {
-    watch: [() => route.fullPath],
-  },
+  () => `blog-entry:${contentPath.value}`,
+  () => queryCollection('blog').path(contentPath.value).first(),
 )
 
-const resolvedPath = computed(() => data.value?.path || route.path)
+const resolvedPath = computed(() => normalizeRoutePath(data.value?.path || contentPath.value))
 const { data: surround } = await useAsyncData(() => `blog-surround:${resolvedPath.value}`, () => {
   return queryCollectionItemSurroundings('blog', resolvedPath.value, {
     fields: ['title', 'description'],
   })
 }, {
   default: () => [],
-  watch: [resolvedPath],
 })
 const coverImage = computed(() => data.value?.coverImage)
 const { style: coverStyle, bind: coverBind } = useImageSrcSet(coverImage, {


### PR DESCRIPTION
## Summary
- normalize dynamic content paths before using them for async data keys and content queries
- apply the same canonical path handling to both `blog/[...path]` and `app/[...path]`
- avoid client-side re-fetches caused by slash-mismatched route watches during hydration

## Why
Direct access to blog article URLs could be normalized to a trailing-slash path in deployment previews. SSR payload keys and Nuxt Content paths were generated without the trailing slash, so the client could briefly miss the content, hit a 404 state, and then recover on CSR.

## Validation
- `pnpm generate`
- verified in browser that `/blog/.../` uses the slashless payload key and no extra content fetch is triggered during initial load