### PR TITLE
Fix ActivityPub content negotiation for blog posts

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -31,13 +31,13 @@ export default defineNuxtConfig({
       }
     },
     prerender: {
-      crawlLinks: true,
-      routes: ['/', '/blog', '/blog/tag']
+      crawlLinks: false,
+      routes: ['/']
     }
   },
   routeRules: {
-    '/blog': { prerender: true },
-    '/blog/**': { prerender: true }
+    '/blog': { prerender: false },
+    '/blog/**': { prerender: false }
   },
   app: {
     head: {

--- a/server/utils/fedifyContent.ts
+++ b/server/utils/fedifyContent.ts
@@ -337,7 +337,7 @@ function normalizeDate(value?: string | Date | null): Temporal.Instant {
 export function resolveFedifyActivityId(articleUrl: URL | string): URL {
   const href = typeof articleUrl === "string" ? articleUrl : articleUrl.href
   const normalized = href.endsWith("/") && href.length > 1 ? href.slice(0, -1) : href
-  return new URL(`${normalized}/activity`)
+  return new URL(`${normalized}#create`)
 }
 
 function appendLegacyActivityIds(collection: Set<string>, baseUrl: URL | string) {


### PR DESCRIPTION
## Summary
- stop prerendering /blog routes so Cloudflare Worker requests can reach Nuxt/Fedify middleware
- make blog post ActivityPub object IDs use the canonical post URL, with Create activities identified by #create
- keep legacy /activity Create dispatcher compatibility for already-published activity IDs

## Verification
- pnpm build
- pnpm wrangler versions upload --dry-run