### PR TITLE
Use dereferenceable Create activity IDs

### DIFF
--- a/server/utils/fedifyContent.ts
+++ b/server/utils/fedifyContent.ts
@@ -337,7 +337,7 @@ function normalizeDate(value?: string | Date | null): Temporal.Instant {
 export function resolveFedifyActivityId(articleUrl: URL | string): URL {
   const href = typeof articleUrl === "string" ? articleUrl : articleUrl.href
   const normalized = href.endsWith("/") && href.length > 1 ? href.slice(0, -1) : href
-  return new URL(`${normalized}#create`)
+  return new URL(`${normalized}/activity`)
 }
 
 function appendLegacyActivityIds(collection: Set<string>, baseUrl: URL | string) {


### PR DESCRIPTION
## Summary
- use /activity URLs for Create activity ids so dereferencing returns the requested Create object
- keep canonical post URLs for Article objects and content negotiation
- keep #create in legacy lookup candidates for already-recorded outbox rows

## Verification
- pnpm build
- pnpm wrangler versions upload --dry-run