### PR TITLE
Add ActivityPub comments for blog posts

### DIFF
--- a/app/components/activitypub-comments.vue
+++ b/app/components/activitypub-comments.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+type Comment = {
+  id: number
+  objectId: string
+  actorName: string
+  actorUrl: string
+  actorIconUrl: string | null
+  contentText: string
+  url: string
+  publishedAt: string | null
+  receivedAt: string
+}
+
+const props = defineProps<{
+  path: string
+  activityUrl: string
+}>()
+
+const { data, pending } = await useAsyncData(
+  () => `activitypub-comments:${props.path}`,
+  () => $fetch<{ comments: Comment[] }>('/api/activitypub/comments', {
+    query: { path: props.path },
+  }),
+  {
+    default: () => ({ comments: [] }),
+  },
+)
+
+const comments = computed(() => data.value?.comments ?? [])
+</script>
+
+<template>
+  <section class="space-y-6">
+    <USeparator />
+
+    <div class="space-y-3">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <h2 class="text-xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
+          댓글
+        </h2>
+        <UBadge variant="subtle" color="neutral">
+          ActivityPub
+        </UBadge>
+      </div>
+
+      <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm leading-relaxed text-gray-700 dark:border-gray-800 dark:bg-gray-900/40 dark:text-gray-300">
+        <p>
+          Mastodon 같은 ActivityPub 클라이언트 검색창에 아래 글 주소를 붙여 넣고, 검색 결과에서 이 글을 연 뒤 답글을 작성하면 이곳에 댓글로 표시됩니다.
+        </p>
+        <p class="mt-3 break-all font-mono text-xs text-gray-600 dark:text-gray-400">
+          {{ activityUrl }}
+        </p>
+      </div>
+    </div>
+
+    <div v-if="pending" class="text-sm text-gray-500">
+      댓글을 불러오는 중입니다.
+    </div>
+
+    <div v-else-if="comments.length" class="space-y-4">
+      <article
+        v-for="comment in comments"
+        :key="comment.objectId"
+        class="rounded-lg border border-gray-200 p-4 dark:border-gray-800"
+      >
+        <div class="flex gap-3">
+          <NuxtLink
+            :to="comment.actorUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="mt-0.5 shrink-0"
+          >
+            <UAvatar
+              :src="comment.actorIconUrl || undefined"
+              :alt="comment.actorName"
+              size="md"
+            />
+          </NuxtLink>
+          <div class="min-w-0 flex-1 space-y-2">
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+              <NuxtLink
+                :to="comment.actorUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="font-medium text-gray-900 hover:underline dark:text-gray-100"
+              >
+                {{ comment.actorName }}
+              </NuxtLink>
+              <NuxtLink
+                :to="comment.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-xs text-gray-500 hover:underline"
+              >
+                <ui-datetime :datetime="comment.publishedAt || comment.receivedAt" />
+              </NuxtLink>
+            </div>
+            <p class="whitespace-pre-wrap break-words text-sm leading-relaxed text-gray-700 dark:text-gray-200">
+              {{ comment.contentText }}
+            </p>
+          </div>
+        </div>
+      </article>
+    </div>
+
+    <p v-else class="text-sm text-gray-500">
+      아직 받은 ActivityPub 댓글이 없습니다.
+    </p>
+  </section>
+</template>

--- a/app/pages/blog/[...path].vue
+++ b/app/pages/blog/[...path].vue
@@ -18,6 +18,7 @@ const { data: surround } = await useAsyncData(() => `blog-surround:${resolvedPat
   default: () => [],
 })
 const coverImage = computed(() => data.value?.coverImage)
+const activityUrl = computed(() => `https://changkyun.kim${resolvedPath.value}`)
 const { style: coverStyle, bind: coverBind } = useImageSrcSet(coverImage, {
   preset: 'cover',
   sizes: 'sm:100vw md:100vw lg:100vw xl:100vw 2xl:100vw',
@@ -75,6 +76,10 @@ useSeoMeta({
             >
               <ContentRenderer :value="data" />
             </section>
+            <ActivitypubComments
+              :path="resolvedPath"
+              :activity-url="activityUrl"
+            />
             <USeparator v-if="surround?.filter(Boolean).length" class="my-8" />
             <UContentSurround v-if="surround?.filter(Boolean).length" :surround="(surround as any)" />
           </UPageBody>

--- a/migrations/0002_activitypub_comments.sql
+++ b/migrations/0002_activitypub_comments.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS activitypub_comments (
   content_text TEXT NOT NULL,
   content_html TEXT,
   url TEXT,
-  published_at TEXT,
+  published_at TEXT NOT NULL,
   received_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   status TEXT NOT NULL DEFAULT 'visible',

--- a/migrations/0002_activitypub_comments.sql
+++ b/migrations/0002_activitypub_comments.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS activitypub_comments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  object_id TEXT NOT NULL,
+  activity_id TEXT,
+  article_id TEXT NOT NULL,
+  article_path TEXT NOT NULL,
+  actor_id TEXT NOT NULL,
+  actor_name TEXT,
+  actor_url TEXT,
+  actor_icon_url TEXT,
+  content_text TEXT NOT NULL,
+  content_html TEXT,
+  url TEXT,
+  published_at TEXT,
+  received_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  status TEXT NOT NULL DEFAULT 'visible',
+  payload TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ix_activitypub_comments_object_id ON activitypub_comments(object_id);
+CREATE INDEX IF NOT EXISTS ix_activitypub_comments_article_status ON activitypub_comments(article_path, status, published_at);
+CREATE INDEX IF NOT EXISTS ix_activitypub_comments_actor ON activitypub_comments(actor_id);

--- a/server/routes/api/activitypub/comments.get.ts
+++ b/server/routes/api/activitypub/comments.get.ts
@@ -1,0 +1,11 @@
+import { getQuery } from "h3"
+
+import { listActivityPubComments } from "../../../utils/fedifyComments"
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const path = typeof query.path === "string" ? query.path : ""
+  return {
+    comments: await listActivityPubComments(path),
+  }
+})

--- a/server/tasks/db/seed.ts
+++ b/server/tasks/db/seed.ts
@@ -77,6 +77,30 @@ export default defineTask({
     );`
     console.info('Ensured content_delivery_state table')
 
+    await db.sql`CREATE TABLE IF NOT EXISTS activitypub_comments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      object_id TEXT NOT NULL,
+      activity_id TEXT,
+      article_id TEXT NOT NULL,
+      article_path TEXT NOT NULL,
+      actor_id TEXT NOT NULL,
+      actor_name TEXT,
+      actor_url TEXT,
+      actor_icon_url TEXT,
+      content_text TEXT NOT NULL,
+      content_html TEXT,
+      url TEXT,
+      published_at TEXT,
+      received_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      status TEXT NOT NULL DEFAULT 'visible',
+      payload TEXT
+    );`
+    await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_activitypub_comments_object_id ON activitypub_comments(object_id);`
+    await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_article_status ON activitypub_comments(article_path, status, published_at);`
+    await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_actor ON activitypub_comments(actor_id);`
+    console.info('Ensured activitypub_comments table and indexes')
+
     // Insert initial data
     const { publicKey, privateKey } = generateRsaKeyPair()
     try {

--- a/server/tasks/db/seed.ts
+++ b/server/tasks/db/seed.ts
@@ -90,7 +90,7 @@ export default defineTask({
       content_text TEXT NOT NULL,
       content_html TEXT,
       url TEXT,
-      published_at TEXT,
+      published_at TEXT NOT NULL,
       received_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
       status TEXT NOT NULL DEFAULT 'visible',

--- a/server/utils/fedify.ts
+++ b/server/utils/fedify.ts
@@ -12,6 +12,7 @@ import {
   Article,
   CryptographicKey,
   Create,
+  Delete,
   Endpoints,
   Follow,
   Image,
@@ -31,6 +32,10 @@ import {
   fetchFedifyContentEntry,
   SITE_ORIGIN,
 } from "./fedifyContent"
+import {
+  markCommentDeletedFromDelete,
+  persistCommentFromCreate,
+} from "./fedifyComments"
 
 type CloudflareEnv = {
   FEDIFY_KV?: any
@@ -413,6 +418,12 @@ builder
     if (object instanceof Follow && object.actorIds.some((id) => id.href === ACTOR_URI.href)) {
       await recordFollowingAccepted(actor.id.href, object)
     }
+  })
+  .on(Create, async (ctx, create) => {
+    await persistCommentFromCreate(ctx, create)
+  })
+  .on(Delete, async (ctx, del) => {
+    await markCommentDeletedFromDelete(ctx, del)
   })
   .on(Activity, async () => {
     // Verified but unsupported activities are intentionally accepted.

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -1,0 +1,391 @@
+import {
+  Create,
+  Delete,
+  Image,
+  isActor,
+  Link,
+  Note,
+  PUBLIC_COLLECTION,
+} from "@fedify/vocab"
+
+import {
+  FEDIFY_BLOG_CANONICAL_HOSTNAMES,
+  FEDIFY_BLOG_COLLECTION_PREFIX,
+  fetchFedifyContentEntry,
+  normalizeArticlePath,
+  SITE_ORIGIN,
+} from "./fedifyContent"
+
+export type ActivityPubComment = {
+  id: number
+  objectId: string
+  articleId: string
+  articlePath: string
+  actorId: string
+  actorName: string
+  actorUrl: string
+  actorIconUrl: string | null
+  contentText: string
+  url: string
+  publishedAt: string | null
+  receivedAt: string
+}
+
+type CommentRow = {
+  id: number
+  object_id: string
+  article_id: string
+  article_path: string
+  actor_id: string
+  actor_name?: string | null
+  actor_url?: string | null
+  actor_icon_url?: string | null
+  content_text: string
+  url?: string | null
+  published_at?: string | null
+  received_at: string
+}
+
+const SITE_HOST = new URL(SITE_ORIGIN).host.toLowerCase()
+const BLOG_HOSTS = new Set(Array.from(FEDIFY_BLOG_CANONICAL_HOSTNAMES, (host) => host.toLowerCase()))
+
+function getDatabase() {
+  return useDatabase()
+}
+
+export async function ensureActivityPubCommentsTable(): Promise<void> {
+  const db = getDatabase()
+  await db.sql`CREATE TABLE IF NOT EXISTS activitypub_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    object_id TEXT NOT NULL,
+    activity_id TEXT,
+    article_id TEXT NOT NULL,
+    article_path TEXT NOT NULL,
+    actor_id TEXT NOT NULL,
+    actor_name TEXT,
+    actor_url TEXT,
+    actor_icon_url TEXT,
+    content_text TEXT NOT NULL,
+    content_html TEXT,
+    url TEXT,
+    published_at TEXT,
+    received_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    status TEXT NOT NULL DEFAULT 'visible',
+    payload TEXT
+  );`
+  await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_activitypub_comments_object_id ON activitypub_comments(object_id);`
+  await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_article_status ON activitypub_comments(article_path, status, published_at);`
+  await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_actor ON activitypub_comments(actor_id);`
+}
+
+function stringifyLanguageValue(value: unknown): string {
+  if (!value) {
+    return ""
+  }
+  if (typeof value === "string") {
+    return value
+  }
+  if (typeof value === "object") {
+    const candidate = value as { value?: unknown; toString?: () => string }
+    if (typeof candidate.value === "string") {
+      return candidate.value
+    }
+    if (typeof candidate.toString === "function") {
+      const text = candidate.toString()
+      return text === "[object Object]" ? "" : text
+    }
+  }
+  return ""
+}
+
+function decodeHtmlEntities(value: string): string {
+  const named: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: "\"",
+  }
+  return value.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (match, entity: string) => {
+    const normalized = entity.toLowerCase()
+    if (normalized.startsWith("#x")) {
+      const codePoint = Number.parseInt(normalized.slice(2), 16)
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match
+    }
+    if (normalized.startsWith("#")) {
+      const codePoint = Number.parseInt(normalized.slice(1), 10)
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match
+    }
+    return named[normalized] ?? match
+  })
+}
+
+function htmlToText(value: string): string {
+  return decodeHtmlEntities(
+    value
+      .replace(/<\s*br\s*\/?>/gi, "\n")
+      .replace(/<\/\s*p\s*>/gi, "\n\n")
+      .replace(/<[^>]*>/g, "")
+      .replace(/\r\n?/g, "\n")
+      .replace(/[ \t]+\n/g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim(),
+  )
+}
+
+function firstUrl(value: URL | Link | null): string | null {
+  if (!value) {
+    return null
+  }
+  if (value instanceof URL) {
+    return value.href
+  }
+  const link = value as Link
+  return link.href?.href ?? link.id?.href ?? null
+}
+
+function firstImageUrl(image: Image | URL | null): string | null {
+  if (!image) {
+    return null
+  }
+  if (image instanceof URL) {
+    return image.href
+  }
+  return firstUrl(image.url)
+}
+
+function normalizeCommentTarget(target: URL): { articleId: string; articlePath: string } | null {
+  const url = new URL(target.href)
+  url.hash = ""
+  const hostname = url.hostname.toLowerCase()
+  let pathname = normalizeArticlePath(url.pathname)
+
+  if (pathname.endsWith("/activity")) {
+    pathname = normalizeArticlePath(pathname.slice(0, -"/activity".length))
+  }
+
+  if (hostname === SITE_HOST) {
+    if (!pathname.startsWith(`${FEDIFY_BLOG_COLLECTION_PREFIX}/`)) {
+      return null
+    }
+  } else if (BLOG_HOSTS.has(hostname)) {
+    if (pathname !== FEDIFY_BLOG_COLLECTION_PREFIX && !pathname.startsWith(`${FEDIFY_BLOG_COLLECTION_PREFIX}/`)) {
+      pathname = normalizeArticlePath(`${FEDIFY_BLOG_COLLECTION_PREFIX}${pathname}`)
+    }
+    if (!pathname.startsWith(`${FEDIFY_BLOG_COLLECTION_PREFIX}/`)) {
+      return null
+    }
+  } else {
+    return null
+  }
+
+  return {
+    articleId: new URL(pathname, SITE_ORIGIN).href,
+    articlePath: pathname,
+  }
+}
+
+function isPublic(note: Note, create: Create): boolean {
+  const publicHref = (PUBLIC_COLLECTION as URL).href
+  const noteAudience = [...note.toIds, ...note.ccIds].map((url) => url.href)
+  const createAudience = [...create.toIds, ...create.ccIds].map((url) => url.href)
+  return noteAudience.includes(publicHref) || createAudience.includes(publicHref)
+}
+
+async function resolveActorProfile(ctx: { documentLoader: any; contextLoader: any }, create: Create, note: Note): Promise<{
+  actorId: string
+  actorName: string
+  actorUrl: string
+  actorIconUrl: string | null
+} | null> {
+  const actor = await create.getActor({
+    documentLoader: ctx.documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })
+  if (!isActor(actor) || !actor.id) {
+    return null
+  }
+
+  const noteActorId = note.attributionId?.href
+  if (noteActorId && noteActorId !== actor.id.href) {
+    return null
+  }
+
+  const actorName = stringifyLanguageValue(actor.name)
+    || stringifyLanguageValue(actor.preferredUsername)
+    || actor.id.hostname
+  const actorUrl = firstUrl(actor.url) ?? actor.id.href
+  const icon = await actor.getIcon({
+    documentLoader: ctx.documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })
+
+  return {
+    actorId: actor.id.href,
+    actorName,
+    actorUrl,
+    actorIconUrl: firstImageUrl(icon),
+  }
+}
+
+export async function persistCommentFromCreate(ctx: { documentLoader: any; contextLoader: any }, create: Create): Promise<boolean> {
+  const object = await create.getObject({
+    documentLoader: ctx.documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })
+  if (!(object instanceof Note) || !object.id) {
+    return false
+  }
+  if (!isPublic(object, create)) {
+    return false
+  }
+
+  const target = object.replyTargetId ? normalizeCommentTarget(object.replyTargetId) : null
+  if (!target) {
+    return false
+  }
+  const entry = await fetchFedifyContentEntry("blog", target.articlePath)
+  if (!entry) {
+    return false
+  }
+
+  const actor = await resolveActorProfile(ctx, create, object)
+  if (!actor) {
+    return false
+  }
+
+  const contentHtml = stringifyLanguageValue(object.content)
+  const contentText = htmlToText(contentHtml)
+  if (!contentText) {
+    return false
+  }
+
+  await ensureActivityPubCommentsTable()
+  const db = getDatabase()
+  const payload = JSON.stringify(await create.toJsonLd({ format: "compact" }))
+  const publishedAt = object.published?.toString() ?? create.published?.toString() ?? null
+  const commentUrl = firstUrl(object.url) ?? object.id.href
+  const activityId = create.id?.href ?? null
+
+  await db.sql`INSERT INTO activitypub_comments (
+    object_id,
+    activity_id,
+    article_id,
+    article_path,
+    actor_id,
+    actor_name,
+    actor_url,
+    actor_icon_url,
+    content_text,
+    content_html,
+    url,
+    published_at,
+    status,
+    payload
+  ) VALUES (
+    ${object.id.href},
+    ${activityId},
+    ${target.articleId},
+    ${target.articlePath},
+    ${actor.actorId},
+    ${actor.actorName},
+    ${actor.actorUrl},
+    ${actor.actorIconUrl},
+    ${contentText},
+    ${contentHtml},
+    ${commentUrl},
+    ${publishedAt},
+    'visible',
+    ${payload}
+  )
+  ON CONFLICT(object_id) DO UPDATE SET
+    activity_id = excluded.activity_id,
+    article_id = excluded.article_id,
+    article_path = excluded.article_path,
+    actor_id = excluded.actor_id,
+    actor_name = excluded.actor_name,
+    actor_url = excluded.actor_url,
+    actor_icon_url = excluded.actor_icon_url,
+    content_text = excluded.content_text,
+    content_html = excluded.content_html,
+    url = excluded.url,
+    published_at = excluded.published_at,
+    status = 'visible',
+    payload = excluded.payload,
+    updated_at = CURRENT_TIMESTAMP`
+
+  return true
+}
+
+export async function markCommentDeletedFromDelete(ctx: { documentLoader: any; contextLoader: any }, del: Delete): Promise<boolean> {
+  const actor = await del.getActor({
+    documentLoader: ctx.documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })
+  if (!isActor(actor) || !actor.id || !del.objectId) {
+    return false
+  }
+
+  await ensureActivityPubCommentsTable()
+  const db = getDatabase()
+  const { rows } = await db.sql`SELECT actor_id FROM activitypub_comments WHERE object_id = ${del.objectId.href} LIMIT 1`
+  const existing = rows?.[0] as { actor_id?: string | null } | undefined
+  if (!existing || existing.actor_id !== actor.id.href) {
+    return false
+  }
+
+  await db.sql`UPDATE activitypub_comments
+    SET status = 'deleted',
+        updated_at = CURRENT_TIMESTAMP
+    WHERE object_id = ${del.objectId.href}
+      AND actor_id = ${actor.id.href}`
+  return true
+}
+
+export async function listActivityPubComments(articlePath: string): Promise<ActivityPubComment[]> {
+  const normalizedPath = normalizeArticlePath(articlePath)
+  if (!normalizedPath.startsWith(`${FEDIFY_BLOG_COLLECTION_PREFIX}/`)) {
+    return []
+  }
+
+  await ensureActivityPubCommentsTable()
+  const db = getDatabase()
+  const { rows } = await db.sql`SELECT
+      id,
+      object_id,
+      article_id,
+      article_path,
+      actor_id,
+      actor_name,
+      actor_url,
+      actor_icon_url,
+      content_text,
+      url,
+      published_at,
+      received_at
+    FROM activitypub_comments
+    WHERE article_path = ${normalizedPath}
+      AND status = 'visible'
+    ORDER BY COALESCE(published_at, received_at) ASC, id ASC`
+
+  return ((rows ?? []) as CommentRow[]).map((row) => ({
+    id: row.id,
+    objectId: row.object_id,
+    articleId: row.article_id,
+    articlePath: row.article_path,
+    actorId: row.actor_id,
+    actorName: row.actor_name || row.actor_id,
+    actorUrl: row.actor_url || row.actor_id,
+    actorIconUrl: row.actor_icon_url || null,
+    contentText: row.content_text,
+    url: row.url || row.object_id,
+    publishedAt: row.published_at || null,
+    receivedAt: row.received_at,
+  }))
+}

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -53,32 +53,6 @@ function getDatabase() {
   return useDatabase()
 }
 
-export async function ensureActivityPubCommentsTable(): Promise<void> {
-  const db = getDatabase()
-  await db.sql`CREATE TABLE IF NOT EXISTS activitypub_comments (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    object_id TEXT NOT NULL,
-    activity_id TEXT,
-    article_id TEXT NOT NULL,
-    article_path TEXT NOT NULL,
-    actor_id TEXT NOT NULL,
-    actor_name TEXT,
-    actor_url TEXT,
-    actor_icon_url TEXT,
-    content_text TEXT NOT NULL,
-    content_html TEXT,
-    url TEXT,
-    published_at TEXT,
-    received_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    status TEXT NOT NULL DEFAULT 'visible',
-    payload TEXT
-  );`
-  await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_activitypub_comments_object_id ON activitypub_comments(object_id);`
-  await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_article_status ON activitypub_comments(article_path, status, published_at);`
-  await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_actor ON activitypub_comments(actor_id);`
-}
-
 function stringifyLanguageValue(value: unknown): string {
   if (!value) {
     return ""
@@ -104,30 +78,87 @@ function decodeHtmlEntities(value: string): string {
     amp: "&",
     apos: "'",
     gt: ">",
+    hellip: "\u2026",
+    ldquo: "\u201c",
     lt: "<",
+    lsquo: "\u2018",
+    mdash: "\u2014",
+    middot: "\u00b7",
     nbsp: " ",
+    ndash: "\u2013",
     quot: "\"",
+    rdquo: "\u201d",
+    rsquo: "\u2019",
   }
   return value.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (match, entity: string) => {
     const normalized = entity.toLowerCase()
     if (normalized.startsWith("#x")) {
       const codePoint = Number.parseInt(normalized.slice(2), 16)
-      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match
+      return isValidUnicodeScalar(codePoint) ? String.fromCodePoint(codePoint) : match
     }
     if (normalized.startsWith("#")) {
       const codePoint = Number.parseInt(normalized.slice(1), 10)
-      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match
+      return isValidUnicodeScalar(codePoint) ? String.fromCodePoint(codePoint) : match
     }
     return named[normalized] ?? match
   })
 }
 
+function isValidUnicodeScalar(codePoint: number): boolean {
+  return Number.isInteger(codePoint)
+    && codePoint >= 0
+    && codePoint <= 0x10ffff
+    && (codePoint < 0xd800 || codePoint > 0xdfff)
+}
+
+function findHtmlTagEnd(value: string, start: number): number {
+  let quote: "\"" | "'" | null = null
+  for (let index = start + 1; index < value.length; index += 1) {
+    const char = value[index]
+    if (quote) {
+      if (char === quote) {
+        quote = null
+      }
+      continue
+    }
+    if (char === "\"" || char === "'") {
+      quote = char
+      continue
+    }
+    if (char === ">") {
+      return index
+    }
+  }
+  return -1
+}
+
+function stripHtmlTags(value: string): string {
+  let text = ""
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]
+    if (char !== "<") {
+      text += char
+      continue
+    }
+
+    const tagEnd = findHtmlTagEnd(value, index)
+    if (tagEnd < 0) {
+      text += char
+      continue
+    }
+
+    const tag = value.slice(index + 1, tagEnd).trim()
+    if (/^br\b/i.test(tag) || /^\/p\b/i.test(tag)) {
+      text += /^br\b/i.test(tag) ? "\n" : "\n\n"
+    }
+    index = tagEnd
+  }
+  return text
+}
+
 function htmlToText(value: string): string {
   return decodeHtmlEntities(
-    value
-      .replace(/<\s*br\s*\/?>/gi, "\n")
-      .replace(/<\/\s*p\s*>/gi, "\n\n")
-      .replace(/<[^>]*>/g, "")
+    stripHtmlTags(value)
       .replace(/\r\n?/g, "\n")
       .replace(/[ \t]+\n/g, "\n")
       .replace(/\n{3,}/g, "\n\n")
@@ -265,10 +296,9 @@ export async function persistCommentFromCreate(ctx: { documentLoader: any; conte
     return false
   }
 
-  await ensureActivityPubCommentsTable()
   const db = getDatabase()
   const payload = JSON.stringify(await create.toJsonLd({ format: "compact" }))
-  const publishedAt = object.published?.toString() ?? create.published?.toString() ?? null
+  const publishedAt = object.published?.toString() ?? create.published?.toString() ?? new Date().toISOString()
   const commentUrl = firstUrl(object.url) ?? object.id.href
   const activityId = create.id?.href ?? null
 
@@ -332,7 +362,6 @@ export async function markCommentDeletedFromDelete(ctx: { documentLoader: any; c
     return false
   }
 
-  await ensureActivityPubCommentsTable()
   const db = getDatabase()
   const { rows } = await db.sql`SELECT actor_id FROM activitypub_comments WHERE object_id = ${del.objectId.href} LIMIT 1`
   const existing = rows?.[0] as { actor_id?: string | null } | undefined
@@ -354,7 +383,6 @@ export async function listActivityPubComments(articlePath: string): Promise<Acti
     return []
   }
 
-  await ensureActivityPubCommentsTable()
   const db = getDatabase()
   const { rows } = await db.sql`SELECT
       id,
@@ -372,7 +400,7 @@ export async function listActivityPubComments(articlePath: string): Promise<Acti
     FROM activitypub_comments
     WHERE article_path = ${normalizedPath}
       AND status = 'visible'
-    ORDER BY COALESCE(published_at, received_at) ASC, id ASC`
+    ORDER BY published_at ASC, id ASC`
 
   return ((rows ?? []) as CommentRow[]).map((row) => ({
     id: row.id,


### PR DESCRIPTION
## Summary
- persist public ActivityPub Create/Note replies to blog Article objects from the inbox
- add a comments API and blog footer UI with ActivityPub reply instructions
- add D1 migration and seed support for activitypub_comments
- handle Delete activities from the original actor by hiding stored comments

## Verification
- pnpm build
- pnpm wrangler versions upload --dry-run