### PR TITLE
Add fediverse reaction display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ sw.*
 *.swp
 
 .data
+
+# Generated Nuxt Content fallback module
+server/utils/contentDump.generated.ts

--- a/app/components/activitypub-reactions.vue
+++ b/app/components/activitypub-reactions.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+type Reaction = {
+  reaction: string
+  count: number
+}
+
+const props = defineProps<{
+  path: string
+}>()
+
+const { data } = await useAsyncData(
+  () => `activitypub-reactions:${props.path}`,
+  () => $fetch<{ reactions: Reaction[] }>('/api/activitypub/reactions', {
+    query: { path: props.path },
+  }),
+  {
+    default: () => ({ reactions: [] }),
+  },
+)
+
+const reactions = computed(() => data.value?.reactions ?? [])
+</script>
+
+<template>
+  <section v-if="reactions.length" class="flex flex-wrap items-center gap-3 text-sm">
+    <h2 class="font-medium text-gray-700 dark:text-gray-200">
+      반응
+    </h2>
+    <ul class="flex flex-wrap gap-2">
+      <li
+        v-for="reaction in reactions"
+        :key="reaction.reaction"
+        class="inline-flex h-8 items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-3 text-sm text-gray-800 dark:border-gray-800 dark:bg-gray-900/40 dark:text-gray-100"
+      >
+        <span>{{ reaction.reaction }}</span>
+        <span v-if="reaction.count > 1" class="font-medium tabular-nums">
+          {{ reaction.count }}
+        </span>
+      </li>
+    </ul>
+  </section>
+</template>

--- a/app/pages/blog/[...path].vue
+++ b/app/pages/blog/[...path].vue
@@ -89,6 +89,9 @@ useHead(() => ({
             >
               <ContentRenderer :value="data" />
             </section>
+            <ActivitypubReactions
+              :path="resolvedPath"
+            />
             <ActivitypubComments
               :path="resolvedPath"
               :activity-url="canonicalActivityUrl"

--- a/migrations/0004_activitypub_reactions.sql
+++ b/migrations/0004_activitypub_reactions.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS activitypub_reactions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  activity_id TEXT,
+  article_id TEXT NOT NULL,
+  article_path TEXT NOT NULL,
+  actor_id TEXT NOT NULL,
+  reaction TEXT NOT NULL,
+  reaction_type TEXT NOT NULL,
+  object_id TEXT NOT NULL,
+  published_at TEXT NOT NULL,
+  received_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  payload TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ix_activitypub_reactions_article_actor ON activitypub_reactions(article_path, actor_id);
+CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_article_reaction ON activitypub_reactions(article_path, reaction);
+CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_actor ON activitypub_reactions(actor_id);
+CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_activity_id ON activitypub_reactions(activity_id);

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,23 @@ import { gunzipSync } from 'node:zlib'
 
 type ContentCollection = 'blog' | 'app'
 
+const contentDumpGeneratedPath = resolve(process.cwd(), '.nuxt/contentDump.generated.ts')
+const emptyContentDumps: Record<ContentCollection, string> = {
+  blog: '',
+  app: '',
+}
+
+function writeContentDumpModule(dumps: Record<ContentCollection, string>) {
+  mkdirSync(resolve(process.cwd(), '.nuxt'), { recursive: true })
+  const source = `const dumps = ${JSON.stringify(dumps)} as const\nexport default dumps\n`
+  if (existsSync(contentDumpGeneratedPath) && readFileSync(contentDumpGeneratedPath, 'utf8') === source) {
+    return
+  }
+  writeFileSync(contentDumpGeneratedPath, source)
+}
+
+writeContentDumpModule(emptyContentDumps)
+
 function isContentDumpForCollection(lines: unknown, collection: ContentCollection) {
   return Array.isArray(lines)
     && lines.some((line) => typeof line === 'string' && line.includes(`_content_${collection}`))
@@ -38,6 +55,9 @@ function readContentDump(collection: ContentCollection) {
 }
 
 export default defineNuxtConfig({
+  alias: {
+    '#content-dump-generated': contentDumpGeneratedPath,
+  },
   typescript: {
     shim: false
   },
@@ -119,12 +139,7 @@ export default defineNuxtConfig({
         blog: readContentDump('blog'),
         app: readContentDump('app'),
       }
-      const generatedDir = resolve(process.cwd(), 'server/utils')
-      mkdirSync(generatedDir, { recursive: true })
-      writeFileSync(
-        resolve(generatedDir, 'contentDump.generated.ts'),
-        `const dumps = ${JSON.stringify(dumps)} as const\nexport default dumps\n`
-      )
+      writeContentDumpModule(dumps)
     },
     'vite:extendConfig'(config) {
       const include = config.optimizeDeps?.include

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,14 +4,14 @@ import { gunzipSync } from 'node:zlib'
 
 type ContentCollection = 'blog' | 'app'
 
-const contentDumpGeneratedPath = resolve(process.cwd(), '.nuxt/contentDump.generated.ts')
+const contentDumpGeneratedPath = resolve(process.cwd(), '.data/contentDump.generated.ts')
 const emptyContentDumps: Record<ContentCollection, string> = {
   blog: '',
   app: '',
 }
 
 function writeContentDumpModule(dumps: Record<ContentCollection, string>) {
-  mkdirSync(resolve(process.cwd(), '.nuxt'), { recursive: true })
+  mkdirSync(resolve(process.cwd(), '.data'), { recursive: true })
   const source = `const dumps = ${JSON.stringify(dumps)} as const\nexport default dumps\n`
   if (existsSync(contentDumpGeneratedPath) && readFileSync(contentDumpGeneratedPath, 'utf8') === source) {
     return

--- a/server/middleware/fedify.ts
+++ b/server/middleware/fedify.ts
@@ -2,9 +2,9 @@ import { queryCollection } from "@nuxt/content/server"
 import { checksums } from "#content/manifest"
 import { createError, getHeader, getRequestURL, readRawBody, setHeader, setResponseStatus } from "h3"
 import type { H3Event } from "h3"
+import embeddedContentDumps from "#content-dump-generated"
 
 import { createFedify, getCloudflareEnv } from "../utils/fedify"
-import embeddedContentDumps from "../utils/contentDump.generated"
 import {
   buildArticleFromEntry,
   buildCreateFromEntry,

--- a/server/routes/api/activitypub/reactions.get.ts
+++ b/server/routes/api/activitypub/reactions.get.ts
@@ -1,0 +1,11 @@
+import { getQuery } from "h3"
+
+import { listActivityPubReactions } from "../../../utils/fedifyReactions"
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const path = typeof query.path === "string" ? query.path : ""
+  return {
+    reactions: await listActivityPubReactions(path),
+  }
+})

--- a/server/utils/activityPubSchema.ts
+++ b/server/utils/activityPubSchema.ts
@@ -87,6 +87,25 @@ async function runActivityPubSchema() {
   await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_article_status ON activitypub_comments(article_path, status, published_at);`
   await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_actor ON activitypub_comments(actor_id);`
 
+  await db.sql`CREATE TABLE IF NOT EXISTS activitypub_reactions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    activity_id TEXT,
+    article_id TEXT NOT NULL,
+    article_path TEXT NOT NULL,
+    actor_id TEXT NOT NULL,
+    reaction TEXT NOT NULL,
+    reaction_type TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    published_at TEXT NOT NULL,
+    received_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    payload TEXT
+  );`
+  await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_activitypub_reactions_article_actor ON activitypub_reactions(article_path, actor_id);`
+  await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_article_reaction ON activitypub_reactions(article_path, reaction);`
+  await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_actor ON activitypub_reactions(actor_id);`
+  await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_activity_id ON activitypub_reactions(activity_id);`
+
   await db.sql`CREATE TABLE IF NOT EXISTS activitypub_feed_actors (
     actor_id TEXT PRIMARY KEY,
     actor_name TEXT,

--- a/server/utils/contentDump.generated.ts
+++ b/server/utils/contentDump.generated.ts
@@ -1,6 +1,0 @@
-const dumps = {
-  blog: "",
-  app: "",
-} as const
-
-export default dumps

--- a/server/utils/fedify.ts
+++ b/server/utils/fedify.ts
@@ -42,8 +42,8 @@ import {
   persistCommentFromCreate,
 } from "./fedifyComments"
 import {
+  handleReactionUndo,
   persistReactionFromActivity,
-  removeReactionFromUndo,
 } from "./fedifyReactions"
 import { persistFeedPostFromCreate } from "./activityPubFeed"
 import { ensureActivityPubSchema } from "./activityPubSchema"
@@ -641,13 +641,8 @@ builder
       }
       return
     }
-    if (object instanceof Like || object instanceof EmojiReact) {
-      await removeReactionFromUndo(ctx, undo)
-      return
-    }
-
-    const reactionRemoved = await removeReactionFromUndo(ctx, undo)
-    if (reactionRemoved) {
+    const reactionHandled = await handleReactionUndo(ctx, undo, { actorId: actor.id.href, object })
+    if (reactionHandled || object instanceof Like || object instanceof EmojiReact) {
       return
     }
 

--- a/server/utils/fedify.ts
+++ b/server/utils/fedify.ts
@@ -16,9 +16,11 @@ import {
   Create,
   Delete,
   Endpoints,
+  EmojiReact,
   Follow,
   Image,
   isActor,
+  Like,
   Person,
   PUBLIC_COLLECTION,
   Undo,
@@ -39,6 +41,10 @@ import {
   markCommentDeletedFromDelete,
   persistCommentFromCreate,
 } from "./fedifyComments"
+import {
+  persistReactionFromActivity,
+  removeReactionFromUndo,
+} from "./fedifyReactions"
 import { persistFeedPostFromCreate } from "./activityPubFeed"
 import { ensureActivityPubSchema } from "./activityPubSchema"
 
@@ -635,6 +641,15 @@ builder
       }
       return
     }
+    if (object instanceof Like || object instanceof EmojiReact) {
+      await removeReactionFromUndo(ctx, undo)
+      return
+    }
+
+    const reactionRemoved = await removeReactionFromUndo(ctx, undo)
+    if (reactionRemoved) {
+      return
+    }
 
     const removed = await removeFollower(actor.id.href, undo.objectId?.href ?? null)
     if (removed) {
@@ -658,6 +673,12 @@ builder
   .on(Create, async (ctx, create) => {
     await persistCommentFromCreate(ctx, create)
     await persistFeedPostFromCreate(ctx, create)
+  })
+  .on(Like, async (ctx, like) => {
+    await persistReactionFromActivity(ctx, like)
+  })
+  .on(EmojiReact, async (ctx, emojiReact) => {
+    await persistReactionFromActivity(ctx, emojiReact)
   })
   .on(Delete, async (ctx, del) => {
     await markCommentDeletedFromDelete(ctx, del)

--- a/server/utils/fedifyReactions.ts
+++ b/server/utils/fedifyReactions.ts
@@ -199,20 +199,25 @@ export async function persistReactionFromActivity(
   return true
 }
 
-export async function removeReactionFromUndo(
+export async function handleReactionUndo(
   ctx: { documentLoader: any; contextLoader: any },
   undo: { objectId: URL | null; getActor: (options: any) => Promise<unknown>; getObject: (options: any) => Promise<unknown> },
+  options: { actorId?: string; object?: unknown } = {},
 ): Promise<boolean> {
-  const actor = await undo.getActor({
-    documentLoader: ctx.documentLoader,
-    contextLoader: ctx.contextLoader,
-    suppressError: true,
-  })
-  if (!isActor(actor) || !actor.id) {
-    return false
+  let actorId = options.actorId ?? null
+  if (!actorId) {
+    const actor = await undo.getActor({
+      documentLoader: ctx.documentLoader,
+      contextLoader: ctx.contextLoader,
+      suppressError: true,
+    })
+    if (!isActor(actor) || !actor.id) {
+      return false
+    }
+    actorId = actor.id.href
   }
 
-  const object = await undo.getObject({
+  const object = options.object ?? await undo.getObject({
     documentLoader: ctx.documentLoader,
     contextLoader: ctx.contextLoader,
     suppressError: true,
@@ -221,29 +226,21 @@ export async function removeReactionFromUndo(
   await ensureActivityPubSchema()
   const db = getDatabase()
   if (object instanceof Like || object instanceof EmojiReact) {
-    const target = await resolveReactionTarget(ctx, object)
-    if (!target) {
-      const activityId = object.id?.href ?? undo.objectId?.href ?? null
-      if (!activityId) {
-        return false
-      }
-      const result = await db.sql`DELETE FROM activitypub_reactions
-        WHERE actor_id = ${actor.id.href}
-          AND activity_id = ${activityId}`
-      return countValue((result as { changes?: unknown }).changes) > 0
+    const activityId = object.id?.href ?? undo.objectId?.href ?? null
+    if (!activityId) {
+      return true
     }
-
-    const result = await db.sql`DELETE FROM activitypub_reactions
-      WHERE actor_id = ${actor.id.href}
-        AND article_path = ${target.articlePath}`
-    return countValue((result as { changes?: unknown }).changes) > 0
+    await db.sql`DELETE FROM activitypub_reactions
+      WHERE actor_id = ${actorId}
+        AND activity_id = ${activityId}`
+    return true
   }
 
   if (!undo.objectId) {
     return false
   }
   const result = await db.sql`DELETE FROM activitypub_reactions
-    WHERE actor_id = ${actor.id.href}
+    WHERE actor_id = ${actorId}
       AND activity_id = ${undo.objectId.href}`
   return countValue((result as { changes?: unknown }).changes) > 0
 }

--- a/server/utils/fedifyReactions.ts
+++ b/server/utils/fedifyReactions.ts
@@ -1,0 +1,269 @@
+import {
+  EmojiReact,
+  isActor,
+  Like,
+} from "@fedify/vocab"
+
+import {
+  FEDIFY_BLOG_CANONICAL_HOSTNAMES,
+  FEDIFY_BLOG_COLLECTION_PREFIX,
+  fetchFedifyContentEntry,
+  normalizeArticlePath,
+  SITE_ORIGIN,
+} from "./fedifyContent"
+import { ensureActivityPubSchema } from "./activityPubSchema"
+
+export type ActivityPubReaction = {
+  reaction: string
+  count: number
+}
+
+type ReactionRow = {
+  reaction: string
+  count: number | bigint | string
+}
+
+type ReactionActivity = Like | EmojiReact
+
+const HEART_REACTION = "❤️"
+const SITE_HOST = new URL(SITE_ORIGIN).host.toLowerCase()
+const BLOG_HOSTS = new Set(Array.from(FEDIFY_BLOG_CANONICAL_HOSTNAMES, (host) => host.toLowerCase()))
+
+function getDatabase() {
+  return useDatabase()
+}
+
+function stringifyLanguageValue(value: unknown): string {
+  if (!value) {
+    return ""
+  }
+  if (typeof value === "string") {
+    return value
+  }
+  if (typeof value === "object") {
+    const candidate = value as { value?: unknown; toString?: () => string }
+    if (typeof candidate.value === "string") {
+      return candidate.value
+    }
+    if (typeof candidate.toString === "function") {
+      const text = candidate.toString()
+      return text === "[object Object]" ? "" : text
+    }
+  }
+  return ""
+}
+
+function countValue(raw: unknown): number {
+  if (typeof raw === "number") {
+    return raw
+  }
+  if (typeof raw === "bigint") {
+    return Number(raw)
+  }
+  if (typeof raw === "string") {
+    return Number.parseInt(raw, 10) || 0
+  }
+  return 0
+}
+
+function normalizeReactionValue(value: string): string | null {
+  const reaction = value.replace(/\s+/g, " ").trim()
+  if (!reaction || reaction.length > 64) {
+    return null
+  }
+  return reaction
+}
+
+function normalizeReactionTarget(target: URL): { articleId: string; articlePath: string; objectId: string } | null {
+  const url = new URL(target.href)
+  url.hash = ""
+  const hostname = url.hostname.toLowerCase()
+  let pathname = normalizeArticlePath(url.pathname)
+
+  if (pathname.endsWith("/activity")) {
+    pathname = normalizeArticlePath(pathname.slice(0, -"/activity".length))
+  }
+
+  if (hostname === SITE_HOST) {
+    if (!pathname.startsWith(`${FEDIFY_BLOG_COLLECTION_PREFIX}/`)) {
+      return null
+    }
+  } else if (BLOG_HOSTS.has(hostname)) {
+    if (pathname !== FEDIFY_BLOG_COLLECTION_PREFIX && !pathname.startsWith(`${FEDIFY_BLOG_COLLECTION_PREFIX}/`)) {
+      pathname = normalizeArticlePath(`${FEDIFY_BLOG_COLLECTION_PREFIX}${pathname}`)
+    }
+    if (!pathname.startsWith(`${FEDIFY_BLOG_COLLECTION_PREFIX}/`)) {
+      return null
+    }
+  } else {
+    return null
+  }
+
+  return {
+    articleId: new URL(pathname, SITE_ORIGIN).href,
+    articlePath: pathname,
+    objectId: target.href,
+  }
+}
+
+async function resolveReactionTarget(ctx: { documentLoader: any; contextLoader: any }, reaction: ReactionActivity) {
+  const targetId = reaction.objectId
+  if (targetId) {
+    return normalizeReactionTarget(targetId)
+  }
+
+  const object = await reaction.getObject({
+    documentLoader: ctx.documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })
+  return object?.id ? normalizeReactionTarget(object.id) : null
+}
+
+async function resolveReactionActor(ctx: { documentLoader: any; contextLoader: any }, reaction: ReactionActivity): Promise<string | null> {
+  const actor = await reaction.getActor({
+    documentLoader: ctx.documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })
+  return isActor(actor) && actor.id ? actor.id.href : null
+}
+
+function getReactionValue(reaction: ReactionActivity): string | null {
+  if (reaction instanceof Like) {
+    return HEART_REACTION
+  }
+  return normalizeReactionValue(
+    stringifyLanguageValue(reaction.content)
+    || stringifyLanguageValue(reaction.name),
+  )
+}
+
+export async function persistReactionFromActivity(
+  ctx: { documentLoader: any; contextLoader: any },
+  reaction: ReactionActivity,
+): Promise<boolean> {
+  const target = await resolveReactionTarget(ctx, reaction)
+  if (!target) {
+    return false
+  }
+  const entry = await fetchFedifyContentEntry("blog", target.articlePath)
+  if (!entry) {
+    return false
+  }
+
+  const actorId = await resolveReactionActor(ctx, reaction)
+  const reactionValue = getReactionValue(reaction)
+  if (!actorId || !reactionValue) {
+    return false
+  }
+
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const payload = JSON.stringify(await reaction.toJsonLd({ format: "compact" }))
+  const publishedAt = reaction.published?.toString() ?? new Date().toISOString()
+  const activityId = reaction.id?.href ?? null
+  const reactionType = reaction instanceof Like ? "Like" : "EmojiReact"
+
+  await db.sql`INSERT INTO activitypub_reactions (
+    activity_id,
+    article_id,
+    article_path,
+    actor_id,
+    reaction,
+    reaction_type,
+    object_id,
+    published_at,
+    payload
+  ) VALUES (
+    ${activityId},
+    ${target.articleId},
+    ${target.articlePath},
+    ${actorId},
+    ${reactionValue},
+    ${reactionType},
+    ${target.objectId},
+    ${publishedAt},
+    ${payload}
+  )
+  ON CONFLICT(article_path, actor_id) DO UPDATE SET
+    activity_id = excluded.activity_id,
+    article_id = excluded.article_id,
+    reaction = excluded.reaction,
+    reaction_type = excluded.reaction_type,
+    object_id = excluded.object_id,
+    published_at = excluded.published_at,
+    payload = excluded.payload,
+    updated_at = CURRENT_TIMESTAMP`
+
+  return true
+}
+
+export async function removeReactionFromUndo(
+  ctx: { documentLoader: any; contextLoader: any },
+  undo: { objectId: URL | null; getActor: (options: any) => Promise<unknown>; getObject: (options: any) => Promise<unknown> },
+): Promise<boolean> {
+  const actor = await undo.getActor({
+    documentLoader: ctx.documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })
+  if (!isActor(actor) || !actor.id) {
+    return false
+  }
+
+  const object = await undo.getObject({
+    documentLoader: ctx.documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })
+
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  if (object instanceof Like || object instanceof EmojiReact) {
+    const target = await resolveReactionTarget(ctx, object)
+    if (!target) {
+      const activityId = object.id?.href ?? undo.objectId?.href ?? null
+      if (!activityId) {
+        return false
+      }
+      const result = await db.sql`DELETE FROM activitypub_reactions
+        WHERE actor_id = ${actor.id.href}
+          AND activity_id = ${activityId}`
+      return countValue((result as { changes?: unknown }).changes) > 0
+    }
+
+    const result = await db.sql`DELETE FROM activitypub_reactions
+      WHERE actor_id = ${actor.id.href}
+        AND article_path = ${target.articlePath}`
+    return countValue((result as { changes?: unknown }).changes) > 0
+  }
+
+  if (!undo.objectId) {
+    return false
+  }
+  const result = await db.sql`DELETE FROM activitypub_reactions
+    WHERE actor_id = ${actor.id.href}
+      AND activity_id = ${undo.objectId.href}`
+  return countValue((result as { changes?: unknown }).changes) > 0
+}
+
+export async function listActivityPubReactions(articlePath: string): Promise<ActivityPubReaction[]> {
+  const normalizedPath = normalizeArticlePath(articlePath)
+  if (!normalizedPath.startsWith(`${FEDIFY_BLOG_COLLECTION_PREFIX}/`)) {
+    return []
+  }
+
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const { rows } = await db.sql`SELECT reaction, COUNT(*) AS count
+    FROM activitypub_reactions
+    WHERE article_path = ${normalizedPath}
+    GROUP BY reaction
+    ORDER BY count DESC, MIN(id) ASC`
+
+  return ((rows ?? []) as ReactionRow[]).map((row) => ({
+    reaction: row.reaction,
+    count: countValue(row.count),
+  }))
+}


### PR DESCRIPTION
## Summary
- Store incoming ActivityPub Like and EmojiReact activities per article and actor
- Normalize Like to ❤️ and expose grouped reaction counts through a new API
- Render a blog post reaction row only when one or more reactions exist

## Review response
- Added server/utils/fedifyReactions.ts to the patch so the new fedify.ts import resolves after merge

## Verification
- pnpm build