### PR TITLE
Fix actor inbox reaction delivery

### DIFF
--- a/server/utils/fedify.ts
+++ b/server/utils/fedify.ts
@@ -84,7 +84,8 @@ function importPemKey(pem: string, usage: KeyUsage[]): Promise<CryptoKey> {
       name: "RSASSA-PKCS1-v1_5",
       hash: { name: "SHA-256" },
     },
-    isPublicKey,
+    // Fedify validates actor keys as extractable before using authenticated document loaders.
+    true,
     usage,
   )
 }


### PR DESCRIPTION
## Summary
- import ActivityPub actor keys as extractable so Fedify can create authenticated document loaders for actor inbox delivery
- keep shared inbox and actor inbox behavior separate while allowing /@me/inbox to verify and process signed Mastodon Favorite activities

## Verification
- pnpm build