### PR TITLE
feat: show ActivityPub reaction actors

### DIFF
--- a/app/components/activitypub-reactions.vue
+++ b/app/components/activitypub-reactions.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
+type ReactionActor = {
+  actorId: string
+  actorName: string
+  actorUrl: string
+  actorIconUrl: string | null
+}
+
 type Reaction = {
   reaction: string
   count: number
+  actors: ReactionActor[]
 }
 
 const props = defineProps<{
@@ -19,6 +27,17 @@ const { data } = await useAsyncData(
 )
 
 const reactions = computed(() => data.value?.reactions ?? [])
+const expandedReactionActors = ref<Set<string>>(new Set())
+
+function visibleActors(reaction: Reaction): ReactionActor[] {
+  return expandedReactionActors.value.has(reaction.reaction)
+    ? reaction.actors
+    : reaction.actors.slice(0, 10)
+}
+
+function expandActors(reaction: string) {
+  expandedReactionActors.value = new Set(expandedReactionActors.value).add(reaction)
+}
 </script>
 
 <template>
@@ -26,17 +45,64 @@ const reactions = computed(() => data.value?.reactions ?? [])
     <h2 class="font-medium text-gray-700 dark:text-gray-200">
       반응
     </h2>
-    <ul class="flex flex-wrap gap-2">
-      <li
+    <div class="flex flex-wrap gap-2">
+      <UPopover
         v-for="reaction in reactions"
         :key="reaction.reaction"
-        class="inline-flex h-8 items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-3 text-sm text-gray-800 dark:border-gray-800 dark:bg-gray-900/40 dark:text-gray-100"
+        mode="hover"
+        arrow
+        :open-delay="100"
+        :close-delay="150"
+        :content="{ align: 'center', side: 'right', sideOffset: 8 }"
+        :ui="{ content: 'w-64 p-2' }"
       >
-        <span>{{ reaction.reaction }}</span>
-        <span v-if="reaction.count > 1" class="font-medium tabular-nums">
-          {{ reaction.count }}
-        </span>
-      </li>
-    </ul>
+        <button
+          type="button"
+          :aria-label="`${reaction.reaction} reaction actors`"
+          class="inline-flex h-8 cursor-default items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-3 text-sm text-gray-800 dark:border-gray-800 dark:bg-gray-900/40 dark:text-gray-100"
+        >
+          <span>{{ reaction.reaction }}</span>
+          <span v-if="reaction.count > 1" class="font-medium tabular-nums">
+            {{ reaction.count }}
+          </span>
+        </button>
+
+        <template #content>
+          <div class="max-h-[24rem] overflow-y-auto">
+            <ul class="space-y-1">
+              <li
+                v-for="actor in visibleActors(reaction)"
+                :key="actor.actorId"
+              >
+                <NuxtLink
+                  :to="actor.actorUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="flex min-w-0 items-center gap-2 rounded-md px-2 py-1 text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
+                >
+                  <UAvatar
+                    :src="actor.actorIconUrl || undefined"
+                    :alt="actor.actorName"
+                    size="xs"
+                    class="shrink-0"
+                  />
+                  <span class="min-w-0 flex-1 truncate font-medium text-gray-800 dark:text-gray-100">
+                    {{ actor.actorName }}
+                  </span>
+                </NuxtLink>
+              </li>
+            </ul>
+            <button
+              v-if="reaction.actors.length > 10 && !expandedReactionActors.has(reaction.reaction)"
+              type="button"
+              class="mt-1 w-full rounded-md px-2 py-1.5 text-left text-sm font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+              @click="expandActors(reaction.reaction)"
+            >
+              ...more
+            </button>
+          </div>
+        </template>
+      </UPopover>
+    </div>
   </section>
 </template>

--- a/migrations/0005_activitypub_reaction_actors.sql
+++ b/migrations/0005_activitypub_reaction_actors.sql
@@ -1,3 +1,4 @@
+-- Columns are defined in CREATE TABLE for fresh installs and managed by this migration for upgrades.
 ALTER TABLE activitypub_reactions ADD COLUMN actor_name TEXT;
 ALTER TABLE activitypub_reactions ADD COLUMN actor_url TEXT;
 ALTER TABLE activitypub_reactions ADD COLUMN actor_icon_url TEXT;

--- a/migrations/0005_activitypub_reaction_actors.sql
+++ b/migrations/0005_activitypub_reaction_actors.sql
@@ -1,0 +1,3 @@
+ALTER TABLE activitypub_reactions ADD COLUMN actor_name TEXT;
+ALTER TABLE activitypub_reactions ADD COLUMN actor_url TEXT;
+ALTER TABLE activitypub_reactions ADD COLUMN actor_icon_url TEXT;

--- a/server/utils/activityPubSchema.ts
+++ b/server/utils/activityPubSchema.ts
@@ -1,34 +1,5 @@
 let schemaPromise: Promise<void> | null = null
 
-function isDuplicateColumnError(error: unknown): boolean {
-  return error instanceof Error && /duplicate column name/i.test(error.message)
-}
-
-async function addReactionActorProfileColumns() {
-  const db = useDatabase()
-  try {
-    await db.sql`ALTER TABLE activitypub_reactions ADD COLUMN actor_name TEXT;`
-  } catch (error) {
-    if (!isDuplicateColumnError(error)) {
-      throw error
-    }
-  }
-  try {
-    await db.sql`ALTER TABLE activitypub_reactions ADD COLUMN actor_url TEXT;`
-  } catch (error) {
-    if (!isDuplicateColumnError(error)) {
-      throw error
-    }
-  }
-  try {
-    await db.sql`ALTER TABLE activitypub_reactions ADD COLUMN actor_icon_url TEXT;`
-  } catch (error) {
-    if (!isDuplicateColumnError(error)) {
-      throw error
-    }
-  }
-}
-
 async function runActivityPubSchema() {
   const db = useDatabase()
 
@@ -137,7 +108,6 @@ async function runActivityPubSchema() {
   await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_article_reaction ON activitypub_reactions(article_path, reaction);`
   await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_actor ON activitypub_reactions(actor_id);`
   await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_activity_id ON activitypub_reactions(activity_id);`
-  await addReactionActorProfileColumns()
 
   await db.sql`CREATE TABLE IF NOT EXISTS activitypub_feed_actors (
     actor_id TEXT PRIMARY KEY,

--- a/server/utils/activityPubSchema.ts
+++ b/server/utils/activityPubSchema.ts
@@ -1,5 +1,34 @@
 let schemaPromise: Promise<void> | null = null
 
+function isDuplicateColumnError(error: unknown): boolean {
+  return error instanceof Error && /duplicate column name/i.test(error.message)
+}
+
+async function addReactionActorProfileColumns() {
+  const db = useDatabase()
+  try {
+    await db.sql`ALTER TABLE activitypub_reactions ADD COLUMN actor_name TEXT;`
+  } catch (error) {
+    if (!isDuplicateColumnError(error)) {
+      throw error
+    }
+  }
+  try {
+    await db.sql`ALTER TABLE activitypub_reactions ADD COLUMN actor_url TEXT;`
+  } catch (error) {
+    if (!isDuplicateColumnError(error)) {
+      throw error
+    }
+  }
+  try {
+    await db.sql`ALTER TABLE activitypub_reactions ADD COLUMN actor_icon_url TEXT;`
+  } catch (error) {
+    if (!isDuplicateColumnError(error)) {
+      throw error
+    }
+  }
+}
+
 async function runActivityPubSchema() {
   const db = useDatabase()
 
@@ -93,6 +122,9 @@ async function runActivityPubSchema() {
     article_id TEXT NOT NULL,
     article_path TEXT NOT NULL,
     actor_id TEXT NOT NULL,
+    actor_name TEXT,
+    actor_url TEXT,
+    actor_icon_url TEXT,
     reaction TEXT NOT NULL,
     reaction_type TEXT NOT NULL,
     object_id TEXT NOT NULL,
@@ -105,6 +137,7 @@ async function runActivityPubSchema() {
   await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_article_reaction ON activitypub_reactions(article_path, reaction);`
   await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_actor ON activitypub_reactions(actor_id);`
   await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_reactions_activity_id ON activitypub_reactions(activity_id);`
+  await addReactionActorProfileColumns()
 
   await db.sql`CREATE TABLE IF NOT EXISTS activitypub_feed_actors (
     actor_id TEXT PRIMARY KEY,

--- a/server/utils/fedify.ts
+++ b/server/utils/fedify.ts
@@ -587,6 +587,7 @@ builder
 
 builder
   .setInboxListeners("/@{identifier}/inbox", "/inbox")
+  .setSharedKeyDispatcher(async () => ({ identifier: ACTOR_IDENTIFIER }))
   .on(Follow, async (ctx, follow) => {
     const actor = await follow.getActor(ctx)
     if (!isActor(actor) || !actor.id) {

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -6,9 +6,11 @@ import {
   Link,
   Note,
   PUBLIC_COLLECTION,
+  type Actor,
 } from "@fedify/vocab"
 
 import {
+  ACTOR_IDENTIFIER,
   FEDIFY_BLOG_CANONICAL_HOSTNAMES,
   FEDIFY_BLOG_COLLECTION_PREFIX,
   fetchFedifyContentEntry,
@@ -49,6 +51,12 @@ type CommentRow = {
 
 const SITE_HOST = new URL(SITE_ORIGIN).host.toLowerCase()
 const BLOG_HOSTS = new Set(Array.from(FEDIFY_BLOG_CANONICAL_HOSTNAMES, (host) => host.toLowerCase()))
+
+type FedifyDocumentContext = {
+  documentLoader: any
+  contextLoader: any
+  getDocumentLoader?: (identity: { identifier: string }) => any
+}
 
 function getDatabase() {
   return useDatabase()
@@ -226,20 +234,57 @@ function isPublic(note: Note, create: Create): boolean {
   return noteAudience.includes(publicHref) || createAudience.includes(publicHref)
 }
 
-async function resolveActorProfile(ctx: { documentLoader: any; contextLoader: any }, create: Create, note: Note): Promise<{
-  actorId: string
-  actorName: string
-  actorUrl: string
-  actorIconUrl: string | null
+async function getLocalActorDocumentLoader(ctx: FedifyDocumentContext): Promise<any | null> {
+  if (typeof ctx.getDocumentLoader !== "function") {
+    return null
+  }
+  try {
+    return await ctx.getDocumentLoader({ identifier: ACTOR_IDENTIFIER })
+  } catch {
+    return null
+  }
+}
+
+async function getCreateActor(ctx: FedifyDocumentContext, create: Create): Promise<{
+  actor: Actor
+  documentLoader: any
 } | null> {
   const actor = await create.getActor({
     documentLoader: ctx.documentLoader,
     contextLoader: ctx.contextLoader,
     suppressError: true,
   })
-  if (!isActor(actor) || !actor.id) {
+  if (isActor(actor) && actor.id) {
+    return { actor, documentLoader: ctx.documentLoader }
+  }
+
+  const documentLoader = await getLocalActorDocumentLoader(ctx)
+  if (!documentLoader || documentLoader === ctx.documentLoader) {
     return null
   }
+
+  const authenticatedActor = await create.getActor({
+    documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })
+  if (!isActor(authenticatedActor) || !authenticatedActor.id) {
+    return null
+  }
+  return { actor: authenticatedActor, documentLoader }
+}
+
+async function resolveActorProfile(ctx: FedifyDocumentContext, create: Create, note: Note): Promise<{
+  actorId: string
+  actorName: string
+  actorUrl: string
+  actorIconUrl: string | null
+} | null> {
+  const actorResult = await getCreateActor(ctx, create)
+  if (!actorResult) {
+    return null
+  }
+  const { actor, documentLoader } = actorResult
 
   const noteActorId = note.attributionId?.href
   if (noteActorId && noteActorId !== actor.id.href) {
@@ -251,7 +296,7 @@ async function resolveActorProfile(ctx: { documentLoader: any; contextLoader: an
     || actor.id.hostname
   const actorUrl = firstUrl(actor.url) ?? actor.id.href
   const icon = await actor.getIcon({
-    documentLoader: ctx.documentLoader,
+    documentLoader,
     contextLoader: ctx.contextLoader,
     suppressError: true,
   })
@@ -264,7 +309,7 @@ async function resolveActorProfile(ctx: { documentLoader: any; contextLoader: an
   }
 }
 
-export async function persistCommentFromCreate(ctx: { documentLoader: any; contextLoader: any }, create: Create): Promise<boolean> {
+export async function persistCommentFromCreate(ctx: FedifyDocumentContext, create: Create): Promise<boolean> {
   const object = await create.getObject({
     documentLoader: ctx.documentLoader,
     contextLoader: ctx.contextLoader,
@@ -354,7 +399,7 @@ export async function persistCommentFromCreate(ctx: { documentLoader: any; conte
   return true
 }
 
-export async function markCommentDeletedFromDelete(ctx: { documentLoader: any; contextLoader: any }, del: Delete): Promise<boolean> {
+export async function markCommentDeletedFromDelete(ctx: FedifyDocumentContext, del: Delete): Promise<boolean> {
   const actor = await del.getActor({
     documentLoader: ctx.documentLoader,
     contextLoader: ctx.contextLoader,

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -6,11 +6,9 @@ import {
   Link,
   Note,
   PUBLIC_COLLECTION,
-  type Actor,
 } from "@fedify/vocab"
 
 import {
-  ACTOR_IDENTIFIER,
   FEDIFY_BLOG_CANONICAL_HOSTNAMES,
   FEDIFY_BLOG_COLLECTION_PREFIX,
   fetchFedifyContentEntry,
@@ -51,12 +49,6 @@ type CommentRow = {
 
 const SITE_HOST = new URL(SITE_ORIGIN).host.toLowerCase()
 const BLOG_HOSTS = new Set(Array.from(FEDIFY_BLOG_CANONICAL_HOSTNAMES, (host) => host.toLowerCase()))
-
-type FedifyDocumentContext = {
-  documentLoader: any
-  contextLoader: any
-  getDocumentLoader?: (identity: { identifier: string }) => any
-}
 
 function getDatabase() {
   return useDatabase()
@@ -234,57 +226,20 @@ function isPublic(note: Note, create: Create): boolean {
   return noteAudience.includes(publicHref) || createAudience.includes(publicHref)
 }
 
-async function getLocalActorDocumentLoader(ctx: FedifyDocumentContext): Promise<any | null> {
-  if (typeof ctx.getDocumentLoader !== "function") {
-    return null
-  }
-  try {
-    return await ctx.getDocumentLoader({ identifier: ACTOR_IDENTIFIER })
-  } catch {
-    return null
-  }
-}
-
-async function getCreateActor(ctx: FedifyDocumentContext, create: Create): Promise<{
-  actor: Actor
-  documentLoader: any
+async function resolveActorProfile(ctx: { documentLoader: any; contextLoader: any }, create: Create, note: Note): Promise<{
+  actorId: string
+  actorName: string
+  actorUrl: string
+  actorIconUrl: string | null
 } | null> {
   const actor = await create.getActor({
     documentLoader: ctx.documentLoader,
     contextLoader: ctx.contextLoader,
     suppressError: true,
   })
-  if (isActor(actor) && actor.id) {
-    return { actor, documentLoader: ctx.documentLoader }
-  }
-
-  const documentLoader = await getLocalActorDocumentLoader(ctx)
-  if (!documentLoader || documentLoader === ctx.documentLoader) {
+  if (!isActor(actor) || !actor.id) {
     return null
   }
-
-  const authenticatedActor = await create.getActor({
-    documentLoader,
-    contextLoader: ctx.contextLoader,
-    suppressError: true,
-  })
-  if (!isActor(authenticatedActor) || !authenticatedActor.id) {
-    return null
-  }
-  return { actor: authenticatedActor, documentLoader }
-}
-
-async function resolveActorProfile(ctx: FedifyDocumentContext, create: Create, note: Note): Promise<{
-  actorId: string
-  actorName: string
-  actorUrl: string
-  actorIconUrl: string | null
-} | null> {
-  const actorResult = await getCreateActor(ctx, create)
-  if (!actorResult) {
-    return null
-  }
-  const { actor, documentLoader } = actorResult
 
   const noteActorId = note.attributionId?.href
   if (noteActorId && noteActorId !== actor.id.href) {
@@ -296,7 +251,7 @@ async function resolveActorProfile(ctx: FedifyDocumentContext, create: Create, n
     || actor.id.hostname
   const actorUrl = firstUrl(actor.url) ?? actor.id.href
   const icon = await actor.getIcon({
-    documentLoader,
+    documentLoader: ctx.documentLoader,
     contextLoader: ctx.contextLoader,
     suppressError: true,
   })
@@ -309,7 +264,7 @@ async function resolveActorProfile(ctx: FedifyDocumentContext, create: Create, n
   }
 }
 
-export async function persistCommentFromCreate(ctx: FedifyDocumentContext, create: Create): Promise<boolean> {
+export async function persistCommentFromCreate(ctx: { documentLoader: any; contextLoader: any }, create: Create): Promise<boolean> {
   const object = await create.getObject({
     documentLoader: ctx.documentLoader,
     contextLoader: ctx.contextLoader,
@@ -399,7 +354,7 @@ export async function persistCommentFromCreate(ctx: FedifyDocumentContext, creat
   return true
 }
 
-export async function markCommentDeletedFromDelete(ctx: FedifyDocumentContext, del: Delete): Promise<boolean> {
+export async function markCommentDeletedFromDelete(ctx: { documentLoader: any; contextLoader: any }, del: Delete): Promise<boolean> {
   const actor = await del.getActor({
     documentLoader: ctx.documentLoader,
     contextLoader: ctx.contextLoader,

--- a/server/utils/fedifyReactions.ts
+++ b/server/utils/fedifyReactions.ts
@@ -1,7 +1,10 @@
 import {
   EmojiReact,
+  Image,
   isActor,
   Like,
+  Link,
+  type Actor,
 } from "@fedify/vocab"
 
 import {
@@ -16,11 +19,29 @@ import { ensureActivityPubSchema } from "./activityPubSchema"
 export type ActivityPubReaction = {
   reaction: string
   count: number
+  actors: ActivityPubReactionActor[]
+}
+
+export type ActivityPubReactionActor = {
+  actorId: string
+  actorName: string
+  actorUrl: string
+  actorIconUrl: string | null
 }
 
 type ReactionRow = {
   reaction: string
   count: number | bigint | string
+  actors?: string | null
+}
+
+type ReactionActorRow = {
+  actor_id: string
+  actor_name?: string | null
+  actor_url?: string | null
+  actor_icon_url?: string | null
+  published_at: string
+  id: number
 }
 
 type ReactionActivity = Like | EmojiReact
@@ -64,6 +85,23 @@ function countValue(raw: unknown): number {
     return Number.parseInt(raw, 10) || 0
   }
   return 0
+}
+
+function parseActorRows(raw: string | null | undefined): ActivityPubReactionActor[] {
+  if (!raw) {
+    return []
+  }
+  try {
+    const actors = JSON.parse(raw) as ReactionActorRow[]
+    return actors.map((actor) => ({
+      actorId: actor.actor_id,
+      actorName: actor.actor_name || actor.actor_id,
+      actorUrl: actor.actor_url || actor.actor_id,
+      actorIconUrl: actor.actor_icon_url || null,
+    }))
+  } catch {
+    return []
+  }
 }
 
 function normalizeReactionValue(value: string): string | null {
@@ -120,13 +158,53 @@ async function resolveReactionTarget(ctx: { documentLoader: any; contextLoader: 
   return object?.id ? normalizeReactionTarget(object.id) : null
 }
 
-async function resolveReactionActor(ctx: { documentLoader: any; contextLoader: any }, reaction: ReactionActivity): Promise<string | null> {
+function firstUrl(value: URL | Link | null): string | null {
+  if (!value) {
+    return null
+  }
+  if (value instanceof URL) {
+    return value.href
+  }
+  const link = value as Link
+  return link.href?.href ?? link.id?.href ?? null
+}
+
+function firstImageUrl(image: Image | URL | null): string | null {
+  if (!image) {
+    return null
+  }
+  if (image instanceof URL) {
+    return image.href
+  }
+  return firstUrl(image.url)
+}
+
+async function resolveActorProfile(ctx: { documentLoader: any; contextLoader: any }, actor: Actor): Promise<ActivityPubReactionActor | null> {
+  if (!actor.id) {
+    return null
+  }
+  const icon = await actor.getIcon({
+    documentLoader: ctx.documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })
+  return {
+    actorId: actor.id.href,
+    actorName: stringifyLanguageValue(actor.name)
+      || stringifyLanguageValue(actor.preferredUsername)
+      || actor.id.hostname,
+    actorUrl: firstUrl(actor.url) ?? actor.id.href,
+    actorIconUrl: firstImageUrl(icon),
+  }
+}
+
+async function resolveReactionActor(ctx: { documentLoader: any; contextLoader: any }, reaction: ReactionActivity): Promise<ActivityPubReactionActor | null> {
   const actor = await reaction.getActor({
     documentLoader: ctx.documentLoader,
     contextLoader: ctx.contextLoader,
     suppressError: true,
   })
-  return isActor(actor) && actor.id ? actor.id.href : null
+  return isActor(actor) ? await resolveActorProfile(ctx, actor) : null
 }
 
 function getReactionValue(reaction: ReactionActivity): string | null {
@@ -152,9 +230,9 @@ export async function persistReactionFromActivity(
     return false
   }
 
-  const actorId = await resolveReactionActor(ctx, reaction)
+  const actor = await resolveReactionActor(ctx, reaction)
   const reactionValue = getReactionValue(reaction)
-  if (!actorId || !reactionValue) {
+  if (!actor || !reactionValue) {
     return false
   }
 
@@ -170,6 +248,9 @@ export async function persistReactionFromActivity(
     article_id,
     article_path,
     actor_id,
+    actor_name,
+    actor_url,
+    actor_icon_url,
     reaction,
     reaction_type,
     object_id,
@@ -179,7 +260,10 @@ export async function persistReactionFromActivity(
     ${activityId},
     ${target.articleId},
     ${target.articlePath},
-    ${actorId},
+    ${actor.actorId},
+    ${actor.actorName},
+    ${actor.actorUrl},
+    ${actor.actorIconUrl},
     ${reactionValue},
     ${reactionType},
     ${target.objectId},
@@ -189,6 +273,9 @@ export async function persistReactionFromActivity(
   ON CONFLICT(article_path, actor_id) DO UPDATE SET
     activity_id = excluded.activity_id,
     article_id = excluded.article_id,
+    actor_name = excluded.actor_name,
+    actor_url = excluded.actor_url,
+    actor_icon_url = excluded.actor_icon_url,
     reaction = excluded.reaction,
     reaction_type = excluded.reaction_type,
     object_id = excluded.object_id,
@@ -253,14 +340,29 @@ export async function listActivityPubReactions(articlePath: string): Promise<Act
 
   await ensureActivityPubSchema()
   const db = getDatabase()
-  const { rows } = await db.sql`SELECT reaction, COUNT(*) AS count
-    FROM activitypub_reactions
-    WHERE article_path = ${normalizedPath}
+  const { rows } = await db.sql`SELECT
+      reaction,
+      COUNT(*) AS count,
+      json_group_array(json_object(
+        'actor_id', actor_id,
+        'actor_name', actor_name,
+        'actor_url', actor_url,
+        'actor_icon_url', actor_icon_url,
+        'published_at', published_at,
+        'id', id
+      )) AS actors
+    FROM (
+      SELECT id, actor_id, actor_name, actor_url, actor_icon_url, reaction, published_at
+      FROM activitypub_reactions
+      WHERE article_path = ${normalizedPath}
+      ORDER BY published_at DESC, id DESC
+    )
     GROUP BY reaction
     ORDER BY count DESC, MIN(id) ASC`
 
   return ((rows ?? []) as ReactionRow[]).map((row) => ({
     reaction: row.reaction,
     count: countValue(row.count),
+    actors: parseActorRows(row.actors),
   }))
 }

--- a/server/utils/fedifyReactions.ts
+++ b/server/utils/fedifyReactions.ts
@@ -29,19 +29,17 @@ export type ActivityPubReactionActor = {
   actorIconUrl: string | null
 }
 
-type ReactionRow = {
+type ReactionCountRow = {
   reaction: string
   count: number | bigint | string
-  actors?: string | null
 }
 
 type ReactionActorRow = {
+  reaction: string
   actor_id: string
   actor_name?: string | null
   actor_url?: string | null
   actor_icon_url?: string | null
-  published_at: string
-  id: number
 }
 
 type ReactionActivity = Like | EmojiReact
@@ -87,20 +85,12 @@ function countValue(raw: unknown): number {
   return 0
 }
 
-function parseActorRows(raw: string | null | undefined): ActivityPubReactionActor[] {
-  if (!raw) {
-    return []
-  }
-  try {
-    const actors = JSON.parse(raw) as ReactionActorRow[]
-    return actors.map((actor) => ({
-      actorId: actor.actor_id,
-      actorName: actor.actor_name || actor.actor_id,
-      actorUrl: actor.actor_url || actor.actor_id,
-      actorIconUrl: actor.actor_icon_url || null,
-    }))
-  } catch {
-    return []
+function mapActorRow(actor: ReactionActorRow): ActivityPubReactionActor {
+  return {
+    actorId: actor.actor_id,
+    actorName: actor.actor_name || actor.actor_id,
+    actorUrl: actor.actor_url || actor.actor_id,
+    actorIconUrl: actor.actor_icon_url || null,
   }
 }
 
@@ -340,29 +330,44 @@ export async function listActivityPubReactions(articlePath: string): Promise<Act
 
   await ensureActivityPubSchema()
   const db = getDatabase()
-  const { rows } = await db.sql`SELECT
+  const { rows: countRows } = await db.sql`SELECT
       reaction,
-      COUNT(*) AS count,
-      json_group_array(json_object(
-        'actor_id', actor_id,
-        'actor_name', actor_name,
-        'actor_url', actor_url,
-        'actor_icon_url', actor_icon_url,
-        'published_at', published_at,
-        'id', id
-      )) AS actors
+      COUNT(*) AS count
+    FROM activitypub_reactions
+    WHERE article_path = ${normalizedPath}
+    GROUP BY reaction
+    ORDER BY count DESC`
+
+  const { rows: actorRows } = await db.sql`SELECT
+      reaction,
+      actor_id,
+      actor_name,
+      actor_url,
+      actor_icon_url
     FROM (
-      SELECT id, actor_id, actor_name, actor_url, actor_icon_url, reaction, published_at
+      SELECT
+        reaction,
+        actor_id,
+        actor_name,
+        actor_url,
+        actor_icon_url,
+        ROW_NUMBER() OVER (PARTITION BY reaction ORDER BY published_at DESC, id DESC) AS reaction_rank
       FROM activitypub_reactions
       WHERE article_path = ${normalizedPath}
-      ORDER BY published_at DESC, id DESC
     )
-    GROUP BY reaction
-    ORDER BY count DESC, MIN(id) ASC`
+    WHERE reaction_rank <= 50
+    ORDER BY reaction, reaction_rank ASC`
 
-  return ((rows ?? []) as ReactionRow[]).map((row) => ({
+  const actorsByReaction = new Map<string, ActivityPubReactionActor[]>()
+  for (const row of (actorRows ?? []) as ReactionActorRow[]) {
+    const actors = actorsByReaction.get(row.reaction) ?? []
+    actors.push(mapActorRow(row))
+    actorsByReaction.set(row.reaction, actors)
+  }
+
+  return ((countRows ?? []) as ReactionCountRow[]).map((row) => ({
     reaction: row.reaction,
     count: countValue(row.count),
-    actors: parseActorRows(row.actors),
+    actors: actorsByReaction.get(row.reaction) ?? [],
   }))
 }


### PR DESCRIPTION
## Summary
- Store ActivityPub reaction actor profile fields so reaction senders can be displayed.
- Extend the reactions API to return actor lists alongside aggregate counts.
- Render reaction senders in a Nuxt UI hover popover with avatars, names, actor links, and a `...more` expansion for lists over 10.
- Configure Fedify's shared inbox key dispatcher so shared-inbox processing uses the local actor's signed document loader from the start, which lets signed-fetch-only servers such as mstdn.ca resolve actors without per-call fallback logic.
- Backfilled the missing mstdn.ca reply from Jim DeLaHunt into the remote D1 `activitypub_comments` table for `/blog/2026-05/08-activitypub-fediverse-site`.

## Commits
- `393131b feat: show activitypub reaction actors`
- `1ca2300 fix: address reaction actor schema/runtime and aggregation review feedback`
- `5596219 fix: fetch signed comment actors`
- `dacb1a5 fix: authenticate shared inbox fetches`

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build`
- Local API smoke check for `/api/activitypub/reactions?path=/blog/2025-09/20-test` with seeded reaction actors
- Remote D1 backfill verification: missing reaction actor fields reduced to 0 rows
- Remote D1/API verification: `/api/activitypub/comments?path=/blog/2026-05/08-activitypub-fediverse-site` now includes the mstdn.ca reply
