### PR TITLE
Add local ActivityPub admin dashboard

### DIFF
--- a/.agents/skills/changkyun-admin/SKILL.md
+++ b/.agents/skills/changkyun-admin/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: changkyun-admin
+description: Manage changkyun.kim ActivityPub admin workflows with the local `pnpm admin` CLI. Use when the user asks to inspect followers, comments, reactions, spam candidates, or to perform a user-specified moderation/reply/reaction action.
+---
+
+# Changkyun ActivityPub Admin
+
+Use this skill to operate the local `changkyun-admin` CLI for ActivityPub admin tasks.
+
+## Scope
+
+Supported workflows:
+
+- View new followers
+- View comments
+- View reactions
+- Identify spam candidates from comments or reactions
+- Delete user-approved spam comments or reactions
+- Reply to a specific comment with text provided by the user
+- React to a specific comment with an emoji provided by the user
+- Unfollow a specific follower when requested
+
+This skill is an operator helper. Do not invent replies, reactions, or moderation actions. Always show the relevant items first and ask for or use the user's explicit instruction before sending a mutation.
+
+## Commands
+
+Run commands from the repository root.
+
+```bash
+pnpm --silent admin list followers --json
+pnpm --silent admin list comments --json
+pnpm --silent admin list reactions --json
+pnpm --silent admin reply <comment-id> --text "<text from user>"
+pnpm --silent admin react-comment <comment-id> "<emoji from user>"
+pnpm --silent admin delete-comment <comment-id>
+pnpm --silent admin delete-reaction <reaction-id>
+pnpm --silent admin unfollow <follower-id>
+```
+
+If working against local dev instead of production:
+
+```bash
+ACTIVITYPUB_ADMIN_BASE_URL=http://localhost:3000 pnpm --silent admin list comments --json
+```
+
+## Workflow
+
+1. Determine the target environment:
+   - Default to production `https://changkyun.kim`.
+   - Use `ACTIVITYPUB_ADMIN_BASE_URL=http://localhost:3000` only when the user asks for local/dev data.
+2. Inspect before mutating:
+   - followers: `pnpm --silent admin list followers --json`
+   - comments: `pnpm --silent admin list comments --json`
+   - reactions: `pnpm --silent admin list reactions --json`
+3. Summarize the concrete items by `id`, actor, article path, and content/reaction.
+4. For spam cleanup:
+   - mark suspicious items as candidates only
+   - do not delete until the user confirms exact IDs or gives a clear rule that maps to exact IDs
+5. For comment replies:
+   - use only the exact reply text supplied by the user
+   - run `pnpm --silent admin reply <comment-id> --text "<text>"`
+6. For comment reactions:
+   - use only the exact emoji supplied by the user, or ask for one if missing
+   - run `pnpm --silent admin react-comment <comment-id> "<emoji>"`
+7. For followers:
+   - list first
+   - run `pnpm --silent admin unfollow <follower-id>` only after explicit instruction
+8. Report executed commands and results concisely.
+
+## Safety Rules
+
+- Never generate an automatic public reply on behalf of the user.
+- Never delete a comment or reaction from a vague spam suspicion alone.
+- Never unfollow based only on a profile name or actor URL if the exact listed ID is ambiguous.
+- Do not print private key material, `.env` contents, or raw secret values.
+- Prefer JSON list commands for inspection so IDs are precise.

--- a/.agents/skills/changkyun-admin/agents/openai.yaml
+++ b/.agents/skills/changkyun-admin/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Changkyun Admin"
+  short_description: "Manage changkyun.kim ActivityPub admin"
+  default_prompt: "Use $changkyun-admin to inspect recent ActivityPub comments and summarize items needing action."

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ node_modules/
 # dotenv environment variables file
 .env
 
+# ActivityPub admin private key material
+activitypub-admin.key
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 

--- a/README.md
+++ b/README.md
@@ -45,95 +45,11 @@ Only allow follows or relay-style actors from sources you trust, because they ca
 
 ## Local ActivityPub Admin CLI
 
-원격 로그인 없이 로컬에서 ActivityPub 상호작용을 처리하려면 `packages/admin` 워크스페이스 패키지를 통해 TUI를 실행합니다.
-토큰이 아니라 로컬 actor private key의 서명을 사용해 인증합니다.
+원격 로그인 없이 ActivityPub 반응을 관리하려면 로컬 워크스페이스 패키지인 `packages/admin`을 사용합니다.
+기본 실행은 배포 도메인(`https://changkyun.kim`)을 대상으로 하는 TUI입니다.
 
 ```bash
-# 1) 관리자 키 준비 (예: DB에서 조회한 PKCS#8 private key)
-export ACTIVITYPUB_ADMIN_PRIVATE_KEY='-----BEGIN PRIVATE KEY-----
-...
------END PRIVATE KEY-----'
-export ACTIVITYPUB_ADMIN_KEY_ID='https://changkyun.kim/@me#main-key'
-
-# 2) TUI 실행
-# 기본 base URL은 배포 도메인: https://changkyun.kim
 pnpm admin
-
-# 로컬 테스트용 (필요 시)
-ACTIVITYPUB_ADMIN_BASE_URL=http://localhost:3000 pnpm admin --private-key-file ./activitypub-admin.key
 ```
 
-로컬 개발 DB(기본 `.data/db.sqlite`)에서 키를 덤프하려면:
-
-```bash
-sqlite3 .data/db.sqlite "SELECT private_key FROM actor WHERE actor_id='https://changkyun.kim/@me';"
-```
-
-키가 없다면 아래 중 한 가지로 생성하세요.
-
-```bash
-# 1) 프로젝트 기동 중이면, DB seed 태스크를 한 번만 실행
-curl -sS http://localhost:3000/__db_seed
-sqlite3 .data/db.sqlite "SELECT private_key, public_key FROM actor WHERE actor_id='https://changkyun.kim/@me';"
-
-# 2) 외부에서 직접 생성(OpenSSL, PKCS#8)
-openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out activitypub-admin.key
-openssl pkey -in activitypub-admin.key -pubout -out activitypub-admin.pub
-```
-
-생성한 `activitypub-admin.key`는 `ACTIVITYPUB_ADMIN_PRIVATE_KEY`(환경변수 주입) 또는
-`ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE`(파일 경로 주입)로 CLI에 넘기면 됩니다.
-키 ID는 공개키의 `#main-key` 형태로 고정하면 됩니다.
-
-```bash
-export ACTIVITYPUB_ADMIN_KEY_ID="https://changkyun.kim/@me#main-key"
-export ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE=/path/to/activitypub-admin.key
-```
-
-배포된 `https://changkyun.kim`에서 이 디바이스 키를 신뢰하려면 공개키도 배포 환경에 등록해야 합니다.
-
-```bash
-# 이 디바이스 키의 공개키 확인
-openssl pkey -in activitypub-admin.key -pubout
-
-# Cloudflare secret 예시: PEM의 줄바꿈을 \n으로 이스케이프해서 저장
-wrangler secret put ACTIVITYPUB_ADMIN_KEY_ID
-wrangler secret put ACTIVITYPUB_ADMIN_PUBLIC_KEY
-```
-
-여러 디바이스를 각각 다른 키로 등록하려면 `ACTIVITYPUB_ADMIN_PUBLIC_KEYS`에 keyId-PublicKey JSON 맵을 넣을 수 있습니다.
-
-```json
-{
-  "https://changkyun.kim/@me#admin-macbook": "-----BEGIN PUBLIC KEY-----\\n...\\n-----END PUBLIC KEY-----\\n",
-  "https://changkyun.kim/@me#admin-desktop": "-----BEGIN PUBLIC KEY-----\\n...\\n-----END PUBLIC KEY-----\\n"
-}
-```
-
-## 복구 전략 (기기 간)
-
-키 관리가 어려운 쪽을 줄이려면 아래를 권장합니다.
-
-- 가장 단순: `activitypub-admin.key`(PKCS#8) 파일을 1Password/Bitwarden/Vault에 암호화 저장 후
-  각 기기에서 `ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE`로 복원
-- 노출 최소화: 비밀관리소에서 키를 보관하고, 배포/로컬 시작 시점에만 환경변수로 주입
-- 백업 체크: 배포 서버에서도 actor가 같은 키로 서명되도록 개인키는 **동일 키**를 사용해야 함
-
-배포 서버의 `.env`에 직접 넣지 말고, CI/CD secret 또는 런타임 secret manager에 주입하세요.
-
-`ACTIVITYPUB_ADMIN_ACTOR_ID` 또는 `ACTIVITYPUB_ADMIN_KEY_ID`가 `.env`가 아니라도
-실행 환경에서 주입 가능하며, 현재 기본값은 `https://changkyun.kim/@me` 기준입니다.
-
-특징:
-
-- argument 없이 실행하면 커서/마우스로 항목을 선택하는 TUI 대시보드가 표시됩니다.
-- 섹션: 팔로우 / 댓글 / 리액션
-- 댓글: 삭제(Hide) 및 대댓글 작성 가능
-- 팔로우: 언팔로우
-- 로컬 패키지(`packages/admin`)로만 실행되며 publish 대상이 아닙니다.
-
-```bash
-# 동작 단축키
-# 1: 팔로우, 2: 댓글, 3: 리액션
-# r: 댓글 답글, d: 선택 항목 삭제(댓글/리액션), u: 팔로우 언팔로우, R: 새로고침, q: 종료
-```
+상세한 키 관리, 복구, 비대화형 명령은 `packages/admin/README.md`를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,98 @@ Remote posts are collected in two ways:
 Stored posts are exposed at `/following/`; `/feed` redirects there. Individual items are readable under `/following/:actor/:id`.
 
 Only allow follows or relay-style actors from sources you trust, because they can increase inbound traffic and affect what appears in the following feed.
+
+## Local ActivityPub Admin CLI
+
+원격 로그인 없이 로컬에서 ActivityPub 상호작용을 처리하려면 `packages/admin` 워크스페이스 패키지를 통해 TUI를 실행합니다.
+토큰이 아니라 로컬 actor private key의 서명을 사용해 인증합니다.
+
+```bash
+# 1) 관리자 키 준비 (예: DB에서 조회한 PKCS#8 private key)
+export ACTIVITYPUB_ADMIN_PRIVATE_KEY='-----BEGIN PRIVATE KEY-----
+...
+-----END PRIVATE KEY-----'
+export ACTIVITYPUB_ADMIN_KEY_ID='https://changkyun.kim/@me#main-key'
+
+# 2) TUI 실행
+# 기본 base URL은 배포 도메인: https://changkyun.kim
+pnpm admin
+
+# 로컬 테스트용 (필요 시)
+ACTIVITYPUB_ADMIN_BASE_URL=http://localhost:3000 pnpm admin --private-key-file ./activitypub-admin.key
+```
+
+로컬 개발 DB(기본 `.data/db.sqlite`)에서 키를 덤프하려면:
+
+```bash
+sqlite3 .data/db.sqlite "SELECT private_key FROM actor WHERE actor_id='https://changkyun.kim/@me';"
+```
+
+키가 없다면 아래 중 한 가지로 생성하세요.
+
+```bash
+# 1) 프로젝트 기동 중이면, DB seed 태스크를 한 번만 실행
+curl -sS http://localhost:3000/__db_seed
+sqlite3 .data/db.sqlite "SELECT private_key, public_key FROM actor WHERE actor_id='https://changkyun.kim/@me';"
+
+# 2) 외부에서 직접 생성(OpenSSL, PKCS#8)
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out activitypub-admin.key
+openssl pkey -in activitypub-admin.key -pubout -out activitypub-admin.pub
+```
+
+생성한 `activitypub-admin.key`는 `ACTIVITYPUB_ADMIN_PRIVATE_KEY`(환경변수 주입) 또는
+`ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE`(파일 경로 주입)로 CLI에 넘기면 됩니다.
+키 ID는 공개키의 `#main-key` 형태로 고정하면 됩니다.
+
+```bash
+export ACTIVITYPUB_ADMIN_KEY_ID="https://changkyun.kim/@me#main-key"
+export ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE=/path/to/activitypub-admin.key
+```
+
+배포된 `https://changkyun.kim`에서 이 디바이스 키를 신뢰하려면 공개키도 배포 환경에 등록해야 합니다.
+
+```bash
+# 이 디바이스 키의 공개키 확인
+openssl pkey -in activitypub-admin.key -pubout
+
+# Cloudflare secret 예시: PEM의 줄바꿈을 \n으로 이스케이프해서 저장
+wrangler secret put ACTIVITYPUB_ADMIN_KEY_ID
+wrangler secret put ACTIVITYPUB_ADMIN_PUBLIC_KEY
+```
+
+여러 디바이스를 각각 다른 키로 등록하려면 `ACTIVITYPUB_ADMIN_PUBLIC_KEYS`에 keyId-PublicKey JSON 맵을 넣을 수 있습니다.
+
+```json
+{
+  "https://changkyun.kim/@me#admin-macbook": "-----BEGIN PUBLIC KEY-----\\n...\\n-----END PUBLIC KEY-----\\n",
+  "https://changkyun.kim/@me#admin-desktop": "-----BEGIN PUBLIC KEY-----\\n...\\n-----END PUBLIC KEY-----\\n"
+}
+```
+
+## 복구 전략 (기기 간)
+
+키 관리가 어려운 쪽을 줄이려면 아래를 권장합니다.
+
+- 가장 단순: `activitypub-admin.key`(PKCS#8) 파일을 1Password/Bitwarden/Vault에 암호화 저장 후
+  각 기기에서 `ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE`로 복원
+- 노출 최소화: 비밀관리소에서 키를 보관하고, 배포/로컬 시작 시점에만 환경변수로 주입
+- 백업 체크: 배포 서버에서도 actor가 같은 키로 서명되도록 개인키는 **동일 키**를 사용해야 함
+
+배포 서버의 `.env`에 직접 넣지 말고, CI/CD secret 또는 런타임 secret manager에 주입하세요.
+
+`ACTIVITYPUB_ADMIN_ACTOR_ID` 또는 `ACTIVITYPUB_ADMIN_KEY_ID`가 `.env`가 아니라도
+실행 환경에서 주입 가능하며, 현재 기본값은 `https://changkyun.kim/@me` 기준입니다.
+
+특징:
+
+- argument 없이 실행하면 커서/마우스로 항목을 선택하는 TUI 대시보드가 표시됩니다.
+- 섹션: 팔로우 / 댓글 / 리액션
+- 댓글: 삭제(Hide) 및 대댓글 작성 가능
+- 팔로우: 언팔로우
+- 로컬 패키지(`packages/admin`)로만 실행되며 publish 대상이 아닙니다.
+
+```bash
+# 동작 단축키
+# 1: 팔로우, 2: 댓글, 3: 리액션
+# r: 댓글 답글, d: 선택 항목 삭제(댓글/리액션), u: 팔로우 언팔로우, R: 새로고침, q: 종료
+```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev": "DEV=1 nuxt dev",
+    "admin": "pnpm --filter changkyun-admin run start",
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "GENERATE=1 nuxi generate"
@@ -34,6 +35,7 @@
     "@fedify/testing": "2.2.0",
     "@iconify-json/lucide": "^1.2.105",
     "@types/negotiator": "^0.6.4",
+    "@types/node": "^25.6.2",
     "glob": "^13.0.6",
     "postcss": "^8.5.14",
     "sharp": "^0.34.5",

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -1,0 +1,71 @@
+# changkyun-admin
+
+Local-only ActivityPub admin CLI for `changkyun.kim`.
+
+The CLI authenticates with ActivityPub-style HTTP signatures. It does not use a login session or admin token.
+
+## Run
+
+```bash
+pnpm admin
+```
+
+Without a command, this opens the TUI dashboard. The default API base URL is `https://changkyun.kim`.
+
+For local development:
+
+```bash
+ACTIVITYPUB_ADMIN_BASE_URL=http://localhost:3000 pnpm admin
+```
+
+## Key Setup
+
+Use a PKCS#8 RSA private key.
+
+```bash
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out activitypub-admin.key
+openssl pkey -in activitypub-admin.key -pubout
+```
+
+Configure the CLI with a private key file:
+
+```bash
+export ACTIVITYPUB_ADMIN_KEY_ID="https://changkyun.kim/@me#main-key"
+export ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE=/path/to/activitypub-admin.key
+```
+
+To allow the deployed site to trust this device, register the matching public key as a Cloudflare secret:
+
+```bash
+openssl pkey -in activitypub-admin.key -pubout | pnpm exec wrangler secret put ACTIVITYPUB_ADMIN_PUBLIC_KEY
+```
+
+For multiple devices, use distinct key IDs and store a JSON map in `ACTIVITYPUB_ADMIN_PUBLIC_KEYS`.
+
+## Recovery
+
+Store `activitypub-admin.key` in a real secret manager such as 1Password, Bitwarden, or Vault. Restore the same PEM file on another device and point `ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE` at it.
+
+Do not commit `.env` or `activitypub-admin.key`.
+
+## Commands
+
+```bash
+pnpm --silent admin list [followers|comments|reactions] [--json]
+pnpm --silent admin reply <comment-id> --text <text>
+pnpm --silent admin react-comment <comment-id> [emoji]
+pnpm --silent admin delete-comment <comment-id>
+pnpm --silent admin delete-reaction <reaction-id>
+pnpm --silent admin unfollow <follower-id>
+```
+
+The command mode is intended for automation helpers. It should still be used as an operator tool: inspect data first, then run mutation commands only when the user explicitly asks for that action.
+
+## TUI Keys
+
+- `1`, `2`, `3`: switch followers, comments, reactions
+- `r`: reply to selected comment
+- `d`: delete selected comment or reaction
+- `u`: unfollow selected follower
+- `R`: refresh
+- `q`: quit

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "changkyun-admin",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Local-only ActivityPub moderation TUI",
+  "type": "module",
+  "bin": {
+    "activitypub-admin": "./src/index.mjs"
+  },
+  "scripts": {
+    "start": "node ./src/index.mjs"
+  },
+  "dependencies": {
+    "blessed": "^0.1.81"
+  }
+}

--- a/packages/admin/src/index.mjs
+++ b/packages/admin/src/index.mjs
@@ -57,6 +57,10 @@ function parseArgs(argv) {
     privateKeyFile: process.env.ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE || "",
     keyId: process.env.ACTIVITYPUB_ADMIN_KEY_ID || DEFAULT_ADMIN_KEY_ID,
     includeDeleted: process.env.ACTIVITYPUB_ADMIN_INCLUDE_DELETED === "1",
+    command: null,
+    args: [],
+    json: false,
+    text: "",
   }
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -87,7 +91,22 @@ function parseArgs(argv) {
     }
     if (arg === "--include-deleted") {
       options.includeDeleted = true
+      continue
     }
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+    if (arg === "--text") {
+      options.text = argv[i + 1] || ""
+      i += 1
+      continue
+    }
+    if (!options.command) {
+      options.command = arg
+      continue
+    }
+    options.args.push(arg)
   }
 
   return options
@@ -99,6 +118,12 @@ activitypub-admin
 
 usage:
   pnpm admin
+  pnpm admin list [followers|comments|reactions] [--json]
+  pnpm admin reply <comment-id> --text <text>
+  pnpm admin react-comment <comment-id> [emoji]
+  pnpm admin delete-comment <comment-id>
+  pnpm admin delete-reaction <reaction-id>
+  pnpm admin unfollow <follower-id>
 
 options: 
   --base-url <url>      API base URL (default: https://changkyun.kim)
@@ -106,6 +131,7 @@ options:
   --private-key-file <p>private key PEM 파일 경로 (env: ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE)
   --key-id <id>        KeyId (default: https://changkyun.kim/@me#main-key, env: ACTIVITYPUB_ADMIN_KEY_ID)
   --include-deleted     삭제된 댓글도 대시보드에 표시
+  --json                명령형 출력에서 JSON 사용
   -h, --help            도움말
 
 조작:
@@ -374,6 +400,102 @@ async function requestAdminAction(baseUrl, signConfig, action, id, payload = {})
   return response.json().catch(() => ({}))
 }
 
+function normalizeSection(value) {
+  if (!value || value === "all") {
+    return null
+  }
+  const section = String(value).toLowerCase()
+  if (["follower", "followers", "follow"].includes(section)) {
+    return "followers"
+  }
+  if (["comment", "comments"].includes(section)) {
+    return "comments"
+  }
+  if (["reaction", "reactions", "like", "likes"].includes(section)) {
+    return "reactions"
+  }
+  throw new Error(`Unknown section: ${value}`)
+}
+
+function parseRequiredId(value, label) {
+  const id = Number.parseInt(String(value || ""), 10)
+  if (!Number.isFinite(id)) {
+    throw new Error(`${label} id가 필요합니다.`)
+  }
+  return id
+}
+
+function writeJson(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`)
+}
+
+function writeList(data, section) {
+  const sections = section ? [section] : SECTION_ORDER
+  for (const current of sections) {
+    const rows = data[current] || []
+    process.stdout.write(`# ${SECTIONS[current].label} (${rows.length})\n`)
+    if (rows.length === 0) {
+      process.stdout.write("항목이 없습니다.\n\n")
+      continue
+    }
+    for (const item of rows) {
+      process.stdout.write(`${item.id}\t${formatRow(current, item)}\n`)
+    }
+    process.stdout.write("\n")
+  }
+}
+
+async function runCommand(options, signConfig) {
+  const command = options.command
+  if (command === "list" || command === "ls" || command === "dashboard") {
+    const section = normalizeSection(options.args[0])
+    const data = await requestAdminData(options.baseUrl, signConfig, options.includeDeleted)
+    if (options.json) {
+      writeJson(section ? data[section] || [] : data)
+      return
+    }
+    writeList(data, section)
+    return
+  }
+
+  if (command === "reply") {
+    const id = parseRequiredId(options.args[0], "comment")
+    const reply = (options.text || options.args.slice(1).join(" ")).trim()
+    if (!reply) {
+      throw new Error("댓글 답글 내용은 --text 또는 인자로 전달해야 합니다.")
+    }
+    writeJson(await requestAdminAction(options.baseUrl, signConfig, "comment.reply", id, { reply }))
+    return
+  }
+
+  if (command === "react-comment") {
+    const id = parseRequiredId(options.args[0], "comment")
+    const reaction = (options.text || options.args[1] || "❤️").trim()
+    writeJson(await requestAdminAction(options.baseUrl, signConfig, "comment.react", id, { reaction }))
+    return
+  }
+
+  if (command === "delete-comment") {
+    const id = parseRequiredId(options.args[0], "comment")
+    writeJson(await requestAdminAction(options.baseUrl, signConfig, "comment.delete", id))
+    return
+  }
+
+  if (command === "delete-reaction") {
+    const id = parseRequiredId(options.args[0], "reaction")
+    writeJson(await requestAdminAction(options.baseUrl, signConfig, "reaction.delete", id))
+    return
+  }
+
+  if (command === "unfollow") {
+    const id = parseRequiredId(options.args[0], "follower")
+    writeJson(await requestAdminAction(options.baseUrl, signConfig, "follower.unfollow", id))
+    return
+  }
+
+  throw new Error(`Unknown admin command: ${command}`)
+}
+
 function createDashboardUi() {
   const screen = blessed.screen({
     smartCSR: true,
@@ -523,6 +645,11 @@ async function bootstrap() {
   const signConfig = {
     keyId: options.keyId,
     privateKey,
+  }
+
+  if (options.command) {
+    await runCommand(options, signConfig)
+    return
   }
 
   const ui = createDashboardUi()

--- a/packages/admin/src/index.mjs
+++ b/packages/admin/src/index.mjs
@@ -15,20 +15,83 @@ const ENV_FILES = [".env", ".env.local"].flatMap((name) => {
   return candidates.map((dir) => path.resolve(dir, name))
 })
 
+function decodeEnvEscape(value) {
+  if (value === "n") {
+    return "\n"
+  }
+  if (value === "r") {
+    return "\r"
+  }
+  if (value === "t") {
+    return "\t"
+  }
+  return value
+}
+
+function parseQuotedEnvValue(rawValue, quote) {
+  let value = ""
+  let escaped = false
+  for (let i = 1; i < rawValue.length; i += 1) {
+    const char = rawValue[i]
+    if (escaped) {
+      value += quote === "\"" ? decodeEnvEscape(char) : char
+      escaped = false
+      continue
+    }
+    if (quote === "\"" && char === "\\") {
+      escaped = true
+      continue
+    }
+    if (char === quote) {
+      return value
+    }
+    value += char
+  }
+  return value
+}
+
+function parseUnquotedEnvValue(rawValue) {
+  for (let i = 0; i < rawValue.length; i += 1) {
+    if (rawValue[i] === "#" && (i === 0 || /\s/.test(rawValue[i - 1]))) {
+      return rawValue.slice(0, i).trimEnd()
+    }
+  }
+  return rawValue.trimEnd()
+}
+
+function parseEnvLine(line) {
+  const trimmed = line.trim()
+  if (!trimmed || trimmed.startsWith("#")) {
+    return null
+  }
+
+  const normalized = trimmed.startsWith("export ") ? trimmed.slice(7).trimStart() : trimmed
+  const index = normalized.indexOf("=")
+  if (index < 0) {
+    return null
+  }
+
+  const key = normalized.slice(0, index).trim()
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+    return null
+  }
+
+  const rawValue = normalized.slice(index + 1).trimStart()
+  if (rawValue.startsWith("\"") || rawValue.startsWith("'")) {
+    return [key, parseQuotedEnvValue(rawValue, rawValue[0])]
+  }
+  return [key, parseUnquotedEnvValue(rawValue)]
+}
+
 function loadEnvFile(filePath) {
   try {
     const text = fs.readFileSync(filePath, "utf8")
     text.split("\n").forEach((line) => {
-      const trimmed = line.trim()
-      if (!trimmed || trimmed.startsWith("#")) {
+      const parsed = parseEnvLine(line)
+      if (!parsed) {
         return
       }
-      const index = trimmed.indexOf("=")
-      if (index < 0) {
-        return
-      }
-      const key = trimmed.slice(0, index).trim()
-      const value = trimmed.slice(index + 1).trim().replace(/^"|"$/g, "")
+      const [key, value] = parsed
       if (key && !Object.prototype.hasOwnProperty.call(process.env, key)) {
         process.env[key] = value
       }

--- a/packages/admin/src/index.mjs
+++ b/packages/admin/src/index.mjs
@@ -1,0 +1,678 @@
+#!/usr/bin/env node
+
+import process from "node:process"
+import fs from "node:fs"
+import path from "node:path"
+import * as blessedModule from "blessed"
+
+const blessed = blessedModule.default ?? blessedModule
+
+const DEFAULT_ADMIN_KEY_ID = "https://changkyun.kim/@me#main-key"
+const DEFAULT_ADMIN_BASE_URL = "https://changkyun.kim"
+const ENV_FILES = [".env", ".env.local"].flatMap((name) => {
+  const cwd = path.resolve(process.cwd())
+  const candidates = [cwd, path.resolve(cwd, ".."), path.resolve(cwd, "..", "..")]
+  return candidates.map((dir) => path.resolve(dir, name))
+})
+
+function loadEnvFile(filePath) {
+  try {
+    const text = fs.readFileSync(filePath, "utf8")
+    text.split("\n").forEach((line) => {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith("#")) {
+        return
+      }
+      const index = trimmed.indexOf("=")
+      if (index < 0) {
+        return
+      }
+      const key = trimmed.slice(0, index).trim()
+      const value = trimmed.slice(index + 1).trim().replace(/^"|"$/g, "")
+      if (key && !Object.prototype.hasOwnProperty.call(process.env, key)) {
+        process.env[key] = value
+      }
+    })
+  } catch {
+    // env file is optional
+  }
+}
+
+for (const filePath of ENV_FILES) {
+  loadEnvFile(filePath)
+}
+
+const SECTIONS = {
+  followers: { key: "followers", label: "팔로우" },
+  comments: { key: "comments", label: "댓글" },
+  reactions: { key: "reactions", label: "리액션" },
+}
+
+const SECTION_ORDER = ["followers", "comments", "reactions"]
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: process.env.ACTIVITYPUB_ADMIN_BASE_URL || DEFAULT_ADMIN_BASE_URL,
+    privateKey: process.env.ACTIVITYPUB_ADMIN_PRIVATE_KEY || "",
+    privateKeyFile: process.env.ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE || "",
+    keyId: process.env.ACTIVITYPUB_ADMIN_KEY_ID || DEFAULT_ADMIN_KEY_ID,
+    includeDeleted: process.env.ACTIVITYPUB_ADMIN_INCLUDE_DELETED === "1",
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === "--help" || arg === "-h") {
+      options.help = true
+      continue
+    }
+    if (arg === "--base-url") {
+      options.baseUrl = argv[i + 1]
+      i += 1
+      continue
+    }
+    if (arg === "--private-key") {
+      options.privateKey = argv[i + 1]
+      i += 1
+      continue
+    }
+    if (arg === "--private-key-file") {
+      options.privateKeyFile = argv[i + 1]
+      i += 1
+      continue
+    }
+    if (arg === "--key-id") {
+      options.keyId = argv[i + 1]
+      i += 1
+      continue
+    }
+    if (arg === "--include-deleted") {
+      options.includeDeleted = true
+    }
+  }
+
+  return options
+}
+
+function usage() {
+  process.stdout.write(`
+activitypub-admin
+
+usage:
+  pnpm admin
+
+options: 
+  --base-url <url>      API base URL (default: https://changkyun.kim)
+  --private-key <pem>   관리자 signing private key (env: ACTIVITYPUB_ADMIN_PRIVATE_KEY)
+  --private-key-file <p>private key PEM 파일 경로 (env: ACTIVITYPUB_ADMIN_PRIVATE_KEY_FILE)
+  --key-id <id>        KeyId (default: https://changkyun.kim/@me#main-key, env: ACTIVITYPUB_ADMIN_KEY_ID)
+  --include-deleted     삭제된 댓글도 대시보드에 표시
+  -h, --help            도움말
+
+조작:
+  [1,2,3] 섹션 전환 | [↑↓/마우스] 항목 선택
+  r: 댓글 답글 | d: 삭제 | u: 팔로워 언팔로우 | R: 새로고침 | q: 종료
+
+`)
+}
+
+function normalizeInputUrl(value) {
+  return value.endsWith("/") ? value.slice(0, -1) : value
+}
+
+function formatTime(value) {
+  if (!value) {
+    return "-"
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  return date.toLocaleString("ko-KR")
+}
+
+function trimText(value, max) {
+  const text = (value || "").replace(/\s+/g, " ").trim()
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text
+}
+
+function loadPrivateKeyFromFile(filePath) {
+  if (!filePath) {
+    return ""
+  }
+  return fs.readFileSync(filePath, "utf8")
+}
+
+function normalizePemText(value) {
+  return (value || "").replace(/\r?\n/g, "\n").trim()
+}
+
+function getFirstExistingFilePath(paths) {
+  for (const candidate of paths) {
+    try {
+      if (fs.existsSync(candidate)) {
+        return candidate
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return ""
+}
+
+async function importPrivateKey(pemText) {
+  const pem = (pemText || "").trim()
+  if (!pem.includes("-----BEGIN PRIVATE KEY-----") || !pem.includes("-----END PRIVATE KEY-----")) {
+    throw new Error("private key는 PKCS#8 PEM 형식이어야 합니다.")
+  }
+  const header = "-----BEGIN PRIVATE KEY-----"
+  const footer = "-----END PRIVATE KEY-----"
+  const body = pem
+    .replace(header, "")
+    .replace(footer, "")
+    .replace(/\s/g, "")
+  const binaryDer = Buffer.from(body, "base64")
+  return crypto.subtle.importKey(
+    "pkcs8",
+    binaryDer,
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: { name: "SHA-256" },
+    },
+    false,
+    ["sign"],
+  )
+}
+
+async function createDigest(value) {
+  const encoder = new TextEncoder()
+  const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(value))
+  return `SHA-256=${Buffer.from(hashBuffer).toString("base64")}`
+}
+
+function buildSigningString(method, path, headerValues, signedHeaders) {
+  return signedHeaders
+    .map((header) => {
+      if (header === "(request-target)") {
+        return `(request-target): ${method.toLowerCase()} ${path}`
+      }
+      return `${header}: ${headerValues[header]}`
+    })
+    .join("\n")
+}
+
+function createSignatureHeader(signingText, headers, keyId) {
+  return `keyId="${keyId}",headers="${headers.join(" ")}",signature="${signingText}"`
+}
+
+async function createSignedHeaders(endpoint, method, payload, keyId, key) {
+  const requestUrl = new URL(endpoint)
+  const path = `${requestUrl.pathname}${requestUrl.search}`
+  const normalized = method.toLowerCase()
+  const bodyText = payload == null ? "" : JSON.stringify(payload)
+  const headers = {
+    "host": requestUrl.host,
+    "date": new Date().toUTCString(),
+  }
+
+  const signingHeaders = ["(request-target)", "host", "date"]
+  const headerValues = {
+    host: headers.host,
+    date: headers.date,
+  }
+
+  if (bodyText) {
+    headers.digest = await createDigest(bodyText)
+    headerValues.digest = headers.digest
+    signingHeaders.push("digest")
+  }
+
+  const signingText = buildSigningString(normalized, path, headerValues, signingHeaders)
+  const signature = await crypto.subtle.sign(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: { name: "SHA-256" },
+    },
+    key,
+    new TextEncoder().encode(signingText),
+  )
+
+  const signatureHeader = createSignatureHeader(Buffer.from(signature).toString("base64"), signingHeaders, keyId)
+  return {
+    date: headers.date,
+    digest: headers.digest,
+    signature: signatureHeader,
+  }
+}
+
+function formatRow(section, item) {
+  if (section === "followers") {
+    return `${item.actorId} | ${item.status} | ${formatTime(item.updatedAt)}`
+  }
+  if (section === "comments") {
+    return `${item.status} ${item.actorId} | ${item.articlePath} | ${trimText(item.contentText, 60)}`
+  }
+
+  return `${item.actorId} | ${item.reaction} | ${item.articlePath}`
+}
+
+function updateStatus(status, message, isError = false) {
+  status.setContent(`
+${message}
+[1]팔로우 [2]댓글 [3]리액션 | [↑↓] 선택/마우스 | r: 답글 | d: 삭제 | u: 언팔로우 | R: 새로고침 | q: 종료`.trim())
+  status.style.fg = isError ? "red" : "green"
+}
+
+function getSectionCount(data, section) {
+  return Array.isArray(data?.[section]) ? data[section].length : 0
+}
+
+function formatSectionCounts(data, currentSection) {
+  return SECTION_ORDER
+    .map((section, index) => {
+      const marker = section === currentSection ? ">" : " "
+      return `${marker} [${index + 1}] ${SECTIONS[section].label}: ${getSectionCount(data, section)}`
+    })
+    .join("   ")
+}
+
+function updateDetail(detail, section, item) {
+  if (!item) {
+    detail.setContent("선택된 항목이 없습니다.")
+    return
+  }
+
+  if (section === "followers") {
+    detail.setContent(`
+유형: 팔로우
+ID: ${item.id}
+Actor: ${item.actorId}
+상태: ${item.status}
+생성: ${formatTime(item.createdAt)}
+수정: ${formatTime(item.updatedAt)}
+    `.trim())
+    return
+  }
+
+  if (section === "comments") {
+    detail.setContent(`
+유형: 댓글
+ID: ${item.id}
+Actor: ${item.actorId}
+경로: ${item.articlePath}
+상태: ${item.status}
+작성시각: ${formatTime(item.publishedAt)}
+내용: ${item.contentText}
+원문객체: ${item.objectId}
+    `.trim())
+    return
+  }
+
+  detail.setContent(`
+유형: 리액션
+ID: ${item.id}
+Actor: ${item.actorId}
+경로: ${item.articlePath}
+리액션: ${item.reaction} (${item.reactionType})
+작성시각: ${formatTime(item.publishedAt)}
+원문객체: ${item.objectId}
+  `.trim())
+}
+
+async function requestAdminData(baseUrl, signConfig, includeDeleted) {
+  const endpoint = `${normalizeInputUrl(baseUrl)}/api/admin/activitypub?includeDeleted=${includeDeleted ? "1" : "0"}`
+  const signing = await createSignedHeaders(endpoint, "GET", null, signConfig.keyId, signConfig.privateKey)
+  const response = await fetch(endpoint, {
+    headers: {
+      Accept: "application/json",
+      Date: signing.date,
+      Signature: signing.signature,
+      ...(signing.digest ? { Digest: signing.digest } : {}),
+    },
+  })
+
+  if (!response.ok) {
+    const message = await readErrorMessage(response, "Failed to load admin data")
+    throw new Error(`HTTP ${response.status} ${response.statusText}: ${message}`)
+  }
+
+  return response.json()
+}
+
+async function readErrorMessage(response, fallback) {
+  const text = await response.text().catch(() => "")
+  if (!text) {
+    return fallback
+  }
+  try {
+    const payload = JSON.parse(text)
+    return payload?.statusMessage || payload?.message || payload?.error || text.slice(0, 160)
+  } catch {
+    return text.replace(/\s+/g, " ").trim().slice(0, 160)
+  }
+}
+
+async function requestAdminAction(baseUrl, signConfig, action, id, payload = {}) {
+  const endpoint = `${normalizeInputUrl(baseUrl)}/api/admin/activitypub`
+  const body = JSON.stringify({ action, id, ...payload })
+  const signing = await createSignedHeaders(endpoint, "POST", { action, id, ...payload }, signConfig.keyId, signConfig.privateKey)
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      Date: signing.date,
+      Signature: signing.signature,
+      Digest: signing.digest,
+      "Content-Type": "application/json",
+    },
+    body,
+  })
+
+  if (!response.ok) {
+    const message = await readErrorMessage(response, "Failed to run admin action")
+    throw new Error(`HTTP ${response.status} ${response.statusText}: ${message}`)
+  }
+  return response.json().catch(() => ({}))
+}
+
+function createDashboardUi() {
+  const screen = blessed.screen({
+    smartCSR: true,
+    fullUnicode: true,
+    title: "ActivityPub Admin",
+    cursor: { artificial: true },
+  })
+
+  screen.key(["C-c", "q"], () => process.exit(0))
+
+  const header = blessed.box({
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 1,
+    style: { fg: "white", bg: "blue" },
+    align: "center",
+    content: "ActivityPub Admin Dashboard",
+  })
+
+  const sectionLabel = blessed.box({
+    top: 1,
+    left: 1,
+    right: 1,
+    height: 1,
+    content: "",
+  })
+
+  const list = blessed.list({
+    top: 3,
+    left: 1,
+    width: "68%",
+    bottom: 4,
+    border: "line",
+    keys: true,
+    mouse: true,
+    vi: true,
+    label: "아이템",
+    items: [],
+    scrollbar: {
+      ch: " ",
+      track: { bg: "yellow" },
+      style: { inverse: true },
+    },
+    style: {
+      selected: {
+        bg: "blue",
+        fg: "white",
+      },
+    },
+  })
+
+  const detail = blessed.box({
+    top: 3,
+    left: "68%",
+    right: 1,
+    bottom: 4,
+    border: "line",
+    label: "상세",
+    scrollable: true,
+    alwaysScroll: true,
+    mouse: true,
+    content: "",
+    keys: true,
+    vi: true,
+  })
+
+  const status = blessed.box({
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 3,
+    border: { type: "line" },
+    label: "조작",
+  })
+
+  screen.append(header)
+  screen.append(sectionLabel)
+  screen.append(list)
+  screen.append(detail)
+  screen.append(status)
+
+  screen.render()
+
+  return { screen, list, detail, sectionLabel, status }
+}
+
+function updateSectionLabel(sectionLabel, state) {
+  sectionLabel.setContent(formatSectionCounts(state, state.section))
+}
+
+function getSelectedItem(data, section, index) {
+  if (index < 0) {
+    return null
+  }
+  return data?.[section]?.[index] ?? null
+}
+
+function openTextPrompt(screen, label) {
+  return new Promise((resolve) => {
+    const prompt = blessed.prompt({
+      parent: screen,
+      top: "center",
+      left: "center",
+      width: "80%",
+      height: "20%",
+      label,
+      border: "line",
+      keys: true,
+      mouse: true,
+    })
+
+    prompt.input("", "", (err, value) => {
+      screen.remove(prompt)
+      screen.render()
+      if (err || !value || typeof value !== "string" || !value.trim()) {
+        resolve(null)
+        return
+      }
+      resolve(value.trim())
+    })
+  })
+}
+
+async function bootstrap() {
+  const options = parseArgs(process.argv.slice(2))
+  if (options.help) {
+    usage()
+    return
+  }
+
+  const privateKeyFilePath = getFirstExistingFilePath([
+    options.privateKeyFile,
+    path.resolve(process.cwd(), "activitypub-admin.key"),
+    path.resolve(process.cwd(), ".activitypub-admin.key"),
+  ].filter(Boolean))
+  const privateKeyText = normalizePemText(options.privateKey || (privateKeyFilePath ? loadPrivateKeyFromFile(privateKeyFilePath) : ""))
+  if (!privateKeyText) {
+    process.stderr.write("ACTIVITYPUB_ADMIN_PRIVATE_KEY 또는 --private-key / --private-key-file를 설정해주세요.\n")
+    process.exit(1)
+  }
+
+  const privateKey = await importPrivateKey(privateKeyText).catch((error) => {
+    process.stderr.write(`${error?.message || error}\n`)
+    process.exit(1)
+  })
+  const signConfig = {
+    keyId: options.keyId,
+    privateKey,
+  }
+
+  const ui = createDashboardUi()
+  const state = {
+    followers: [],
+    comments: [],
+    reactions: [],
+    section: "followers",
+    selectedIndex: 0,
+    userSelectedSection: false,
+  }
+
+  updateSectionLabel(ui.sectionLabel, state)
+
+  async function refresh() {
+    try {
+      updateStatus(ui.status, `데이터 새로고침 중... (${options.baseUrl})`, false)
+      ui.screen.render()
+      const payload = await requestAdminData(options.baseUrl, signConfig, options.includeDeleted)
+      state.followers = payload.followers || []
+      state.comments = payload.comments || []
+      state.reactions = payload.reactions || []
+
+      if (!state.userSelectedSection && getSectionCount(state, state.section) === 0) {
+        const firstNonEmptySection = SECTION_ORDER.find((section) => getSectionCount(state, section) > 0)
+        if (firstNonEmptySection) {
+          state.section = firstNonEmptySection
+          state.selectedIndex = 0
+        }
+      }
+
+      const listData = state[state.section]
+      if (listData.length === 0) {
+        state.selectedIndex = -1
+        ui.list.setItems(["항목이 없습니다."])
+      } else {
+        ui.list.setItems(listData.map((item) => formatRow(state.section, item)))
+        state.selectedIndex = Math.max(0, Math.min(state.selectedIndex, listData.length - 1))
+        ui.list.select(state.selectedIndex)
+      }
+
+      updateDetail(ui.detail, state.section, getSelectedItem(state, state.section, state.selectedIndex))
+      updateSectionLabel(ui.sectionLabel, state)
+      updateStatus(ui.status, `${SECTIONS[state.section].label} ${listData.length}개`, false)
+      ui.screen.render()
+    } catch (error) {
+      updateStatus(ui.status, String(error?.message || error), true)
+      ui.screen.render()
+    }
+  }
+
+  function switchSection(section) {
+    if (state.section === section) {
+      return
+    }
+    state.section = section
+    state.selectedIndex = 0
+    state.userSelectedSection = true
+    void refresh()
+  }
+
+  function applySelection(index) {
+    state.selectedIndex = index
+    updateDetail(ui.detail, state.section, getSelectedItem(state, state.section, index))
+    ui.screen.render()
+  }
+
+  async function handleAction(action) {
+    const item = getSelectedItem(state, state.section, state.selectedIndex)
+    if (!item) {
+      updateStatus(ui.status, "선택된 항목이 없습니다.", true)
+      return
+    }
+
+    if (action === "reply") {
+      if (state.section !== "comments") {
+        updateStatus(ui.status, "댓글 섹션에서만 대댓글을 작성할 수 있습니다.", true)
+        return
+      }
+      const value = await openTextPrompt(ui.screen, "대댓글")
+      if (!value) {
+        updateStatus(ui.status, "답글이 취소되었습니다.")
+        return
+      }
+      try {
+        await requestAdminAction(options.baseUrl, signConfig, "comment.reply", item.id, { reply: value })
+        updateStatus(ui.status, `댓글 ID:${item.id} 대댓글 전송 완료`)
+        await refresh()
+      } catch (error) {
+        updateStatus(ui.status, String(error?.message || error), true)
+      }
+      return
+    }
+
+    if (action === "delete") {
+      if (state.section === "followers") {
+        updateStatus(ui.status, "팔로워는 언팔로우(u)로 처리하세요.", true)
+        return
+      }
+      const actionName = state.section === "comments" ? "comment.delete" : "reaction.delete"
+      try {
+        await requestAdminAction(options.baseUrl, signConfig, actionName, item.id)
+        updateStatus(ui.status, `항목 ID:${item.id} 삭제 처리`)
+        await refresh()
+      } catch (error) {
+        updateStatus(ui.status, String(error?.message || error), true)
+      }
+      return
+    }
+
+    if (action === "unfollow") {
+      if (state.section !== "followers") {
+        updateStatus(ui.status, "팔로우 섹션에서만 언팔로우하세요.", true)
+        return
+      }
+      try {
+        await requestAdminAction(options.baseUrl, signConfig, "follower.unfollow", item.id)
+        updateStatus(ui.status, `팔로워 ID:${item.id} 언팔로우 처리`)
+        await refresh()
+      } catch (error) {
+        updateStatus(ui.status, String(error?.message || error), true)
+      }
+    }
+  }
+
+  ui.list.on("select", (_, index) => {
+    applySelection(index)
+  })
+
+  ui.screen.key(["1"], () => switchSection(SECTION_ORDER[0]))
+  ui.screen.key(["2"], () => switchSection(SECTION_ORDER[1]))
+  ui.screen.key(["3"], () => switchSection(SECTION_ORDER[2]))
+  ui.screen.key(["r"], () => {
+    void handleAction("reply")
+  })
+  ui.screen.key(["d", "D", "x", "X"], () => {
+    void handleAction("delete")
+  })
+  ui.screen.key(["u", "U"], () => {
+    void handleAction("unfollow")
+  })
+  ui.screen.key(["tab", "space", "R", "C-r"], () => {
+    void refresh()
+  })
+
+  ui.list.focus()
+  await refresh()
+}
+
+bootstrap().catch((error) => {
+  process.stderr.write(`admin cli failed: ${error?.message || error}\n`)
+  process.exit(1)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 2.0.0(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magicast@0.5.2)(srvx@0.11.15)
       '@nuxt/ui':
         specifier: ^4.7.1
-        version: 4.7.1(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@nuxt/content@3.13.0(better-sqlite3@12.9.0)(magicast@0.5.2))(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4(better-sqlite3@12.9.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.4)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue-router@5.0.6(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))(yjs@13.6.29)(zod@3.25.76)
+        version: 4.7.1(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@nuxt/content@3.13.0(better-sqlite3@12.9.0)(magicast@0.5.2))(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4(better-sqlite3@12.9.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.4)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue-router@5.0.6(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))(yjs@13.6.29)(zod@3.25.76)
       '@popperjs/core':
         specifier: ^2.11.8
         version: 2.11.8
@@ -56,7 +56,7 @@ importers:
         version: 1.0.0
       nuxt:
         specifier: ^4.4.4
-        version: 4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4)
+        version: 4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4)
     devDependencies:
       '@fedify/testing':
         specifier: 2.2.0
@@ -67,6 +67,9 @@ importers:
       '@types/negotiator':
         specifier: ^0.6.4
         version: 0.6.4
+      '@types/node':
+        specifier: ^25.6.2
+        version: 25.6.2
       glob:
         specifier: ^13.0.6
         version: 13.0.6
@@ -82,6 +85,12 @@ importers:
       wrangler:
         specifier: ^4.88.0
         version: 4.88.0(@cloudflare/workers-types@4.20260507.1)
+
+  packages/admin:
+    dependencies:
+      blessed:
+        specifier: ^0.1.81
+        version: 0.1.81
 
 packages:
 
@@ -2367,6 +2376,9 @@ packages:
   '@types/negotiator@0.6.4':
     resolution: {integrity: sha512-elf6BsTq+AkyNsb2h5cGNst2Mc7dPliVoAPm1fXglC/BM3f2pFA40BaSSv3E5lyHteEawVKLP+8TwiY1DMNb3A==}
 
+  '@types/node@25.6.2':
+    resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
+
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
@@ -2741,6 +2753,11 @@ packages:
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  blessed@0.1.81:
+    resolution: {integrity: sha512-LoF5gae+hlmfORcG1M5+5XZi4LBmvlXTzwJWzUlPryN/SJdSflZvROM2TwkT0GMpq7oqT48NRd4GS7BiVBc5OQ==}
+    engines: {node: '>= 0.8.0'}
+    hasBin: true
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -5230,6 +5247,9 @@ packages:
   unctx@2.5.0:
     resolution: {integrity: sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==}
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
@@ -6697,11 +6717,11 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))':
+  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       execa: 8.0.1
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - magicast
 
@@ -6716,9 +6736,9 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.7.4
 
-  '@nuxt/devtools@3.2.4(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))':
+  '@nuxt/devtools@3.2.4(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
       '@nuxt/devtools-wizard': 3.2.4
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@vue/devtools-core': 8.1.1(vue@3.5.34(typescript@5.9.3))
@@ -6746,9 +6766,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.0
       tinyglobby: 0.2.16
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.4(magicast@0.5.2))(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
-      vite-plugin-vue-tracer: 1.3.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.4(magicast@0.5.2))(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
+      vite-plugin-vue-tracer: 1.3.0(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
       which: 6.0.1
       ws: 8.20.0
     transitivePeerDependencies:
@@ -6757,13 +6777,13 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/fonts@0.14.0(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magicast@0.5.2)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))':
+  '@nuxt/fonts@0.14.0(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magicast@0.5.2)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))':
     dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
-      fontless: 0.2.1(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
+      fontless: 0.2.1(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
       h3: 1.15.11
       magic-regexp: 0.10.0
       ofetch: 1.5.1
@@ -6797,13 +6817,13 @@ snapshots:
       - uploadthing
       - vite
 
-  '@nuxt/icon@2.2.2(magicast@0.5.2)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))':
+  '@nuxt/icon@2.2.2(magicast@0.5.2)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@iconify/collections': 1.0.680
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.1.2
       '@iconify/vue': 5.0.1(vue@3.5.34(typescript@5.9.3))
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       consola: 3.4.2
       local-pkg: 1.1.2
@@ -6906,7 +6926,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(better-sqlite3@12.9.0)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4))(oxc-parser@0.128.0)(srvx@0.11.15)(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(better-sqlite3@12.9.0)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4))(oxc-parser@0.128.0)(srvx@0.11.15)(typescript@5.9.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -6925,7 +6945,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(better-sqlite3@12.9.0)(oxc-parser@0.128.0)(srvx@0.11.15)
-      nuxt: 4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4)
+      nuxt: 4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -6993,18 +7013,18 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/ui@4.7.1(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@nuxt/content@3.13.0(better-sqlite3@12.9.0)(magicast@0.5.2))(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4(better-sqlite3@12.9.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.4)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue-router@5.0.6(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))(yjs@13.6.29)(zod@3.25.76)':
+  '@nuxt/ui@4.7.1(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@nuxt/content@3.13.0(better-sqlite3@12.9.0)(magicast@0.5.2))(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4(better-sqlite3@12.9.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.4)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue-router@5.0.6(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))(yjs@13.6.29)(zod@3.25.76)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.1(vue@3.5.34(typescript@5.9.3))
-      '@nuxt/fonts': 0.14.0(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magicast@0.5.2)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
-      '@nuxt/icon': 2.2.2(magicast@0.5.2)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
+      '@nuxt/fonts': 0.14.0(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magicast@0.5.2)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
+      '@nuxt/icon': 2.2.2(magicast@0.5.2)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@nuxt/schema': 4.4.4
       '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
       '@standard-schema/spec': 1.1.0
       '@tailwindcss/postcss': 4.2.4
-      '@tailwindcss/vite': 4.2.4(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
+      '@tailwindcss/vite': 4.2.4(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
       '@tanstack/vue-table': 8.21.3(vue@3.5.34(typescript@5.9.3))
       '@tanstack/vue-virtual': 3.13.24(vue@3.5.34(typescript@5.9.3))
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
@@ -7107,12 +7127,12 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.4)':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.2)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.4)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.3)
-      '@vitejs/plugin-vue': 6.0.6(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.6(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
       autoprefixer: 10.5.0(postcss@8.5.14)
       consola: 3.4.2
       cssnano: 7.1.9(postcss@8.5.14)
@@ -7125,7 +7145,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4)
+      nuxt: 4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -7134,9 +7154,9 @@ snapshots:
       std-env: 4.1.0
       ufo: 1.6.4
       unenv: 2.0.0-rc.24
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
-      vite-node: 5.3.0(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
-      vite-plugin-checker: 0.13.0(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite-node: 5.3.0(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite-plugin-checker: 0.13.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
       vue: 3.5.34(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -7817,12 +7837,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.4
 
-  '@tailwindcss/vite@4.2.4(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))':
+  '@tailwindcss/vite@4.2.4(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))':
     dependencies:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
 
   '@tanstack/table-core@8.21.3': {}
 
@@ -8089,6 +8109,10 @@ snapshots:
 
   '@types/negotiator@0.6.4': {}
 
+  '@types/node@25.6.2':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
@@ -8130,22 +8154,22 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@rolldown/pluginutils': 1.0.0-rc.18
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
       vue: 3.5.34(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.6(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.6(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
       vue: 3.5.34(typescript@5.9.3)
 
   '@volar/language-core@2.4.28':
@@ -8486,6 +8510,8 @@ snapshots:
       readable-stream: 3.6.2
 
   blake3-wasm@2.1.5: {}
+
+  blessed@0.1.81: {}
 
   boolbase@1.0.0: {}
 
@@ -9138,7 +9164,7 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
-  fontless@0.2.1(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)):
+  fontless@0.2.1(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)):
     dependencies:
       consola: 3.4.2
       css-tree: 3.2.1
@@ -9154,7 +9180,7 @@ snapshots:
       unifont: 0.7.4
       unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)
     optionalDependencies:
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -10435,16 +10461,16 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4):
+  nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
+      '@nuxt/devtools': 3.2.4(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(better-sqlite3@12.9.0)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4))(oxc-parser@0.128.0)(srvx@0.11.15)(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(better-sqlite3@12.9.0)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4))(oxc-parser@0.128.0)(srvx@0.11.15)(typescript@5.9.3)
       '@nuxt/schema': 4.4.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.4)
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.2)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(yaml@2.8.4))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.8.4)
       '@unhead/vue': 2.1.13(vue@3.5.34(typescript@5.9.3))
       '@vue/shared': 3.5.34
       chokidar: 5.0.0
@@ -10494,6 +10520,7 @@ snapshots:
       vue-router: 5.0.6(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@5.9.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
+      '@types/node': 25.6.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11748,6 +11775,8 @@ snapshots:
       magic-string: 0.30.21
       unplugin: 2.3.11
 
+  undici-types@7.19.2: {}
+
   undici@6.25.0: {}
 
   undici@7.24.8: {}
@@ -11976,23 +12005,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-dev-rpc@1.1.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)):
+  vite-dev-rpc@1.1.0(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)):
     dependencies:
       birpc: 2.9.0
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
-      vite-hot-client: 2.2.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite-hot-client: 2.2.0(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
 
-  vite-hot-client@2.2.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)):
+  vite-hot-client@2.2.0(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)):
     dependencies:
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
 
-  vite-node@5.3.0(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4):
+  vite-node@5.3.0(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.1.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -12006,7 +12035,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.13.0(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)):
+  vite-plugin-checker@0.13.0(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chokidar: 4.0.3
@@ -12016,12 +12045,12 @@ snapshots:
       proper-lockfile: 4.1.2
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.16
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
       vscode-uri: 3.1.0
     optionalDependencies:
       typescript: 5.9.3
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.4(magicast@0.5.2))(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.4(magicast@0.5.2))(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -12031,24 +12060,24 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
-      vite-dev-rpc: 1.1.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite-dev-rpc: 1.1.0(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))
     optionalDependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.3.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3)):
+  vite-plugin-vue-tracer@1.3.0(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4)
       vue: 3.5.34(typescript@5.9.3)
 
-  vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4):
+  vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -12057,6 +12086,7 @@ snapshots:
       rollup: 4.60.3
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 25.6.2
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - .
+  - packages/*
+

--- a/server/routes/api/admin/activitypub.get.ts
+++ b/server/routes/api/admin/activitypub.get.ts
@@ -1,0 +1,17 @@
+import { getQuery } from "h3"
+
+import {
+  getAdminDashboardData,
+} from "../../../utils/activityPubAdmin"
+import { unauthorizedError, verifyActivityPubAdminRequestSignature } from "../../../utils/activityPubAdminAuth"
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const includeDeleted = query.includeDeleted === "1" || query.includeDeleted === "true"
+
+  if (!(await verifyActivityPubAdminRequestSignature(event))) {
+    unauthorizedError()
+  }
+
+  return await getAdminDashboardData(includeDeleted)
+})

--- a/server/routes/api/admin/activitypub.post.ts
+++ b/server/routes/api/admin/activitypub.post.ts
@@ -5,6 +5,7 @@ import {
   hideActivityPubCommentById,
   removeFollowerById,
   deleteActivityPubReactionById,
+  reactActivityPubCommentById,
   replyActivityPubCommentById,
 } from "../../../utils/activityPubAdmin"
 import { unauthorizedError, verifyActivityPubAdminRequestSignature } from "../../../utils/activityPubAdminAuth"
@@ -13,6 +14,7 @@ type AdminActionBody = {
   action?: string
   id?: number | string
   reply?: string
+  reaction?: string
 }
 
 function parseBody(rawBody: string | false | undefined): AdminActionBody {
@@ -76,6 +78,20 @@ export default defineEventHandler(async (event) => {
       id,
       actorId: result.actorId,
       commentObjectId: result.commentObjectId,
+    }
+  }
+
+  if (action === "comment.react") {
+    const reaction = typeof body?.reaction === "string" ? body.reaction.trim() : "❤️"
+    const result = await reactActivityPubCommentById(id, reaction || "❤️", event)
+    return {
+      ok: true,
+      action,
+      id,
+      actorId: result.actorId,
+      commentObjectId: result.commentObjectId,
+      reaction: result.reaction,
+      reactionType: result.reactionType,
     }
   }
 

--- a/server/routes/api/admin/activitypub.post.ts
+++ b/server/routes/api/admin/activitypub.post.ts
@@ -1,0 +1,105 @@
+import { readRawBody } from "h3"
+import { createError } from "h3"
+
+import {
+  hideActivityPubCommentById,
+  removeFollowerById,
+  deleteActivityPubReactionById,
+  replyActivityPubCommentById,
+} from "../../../utils/activityPubAdmin"
+import { unauthorizedError, verifyActivityPubAdminRequestSignature } from "../../../utils/activityPubAdminAuth"
+
+type AdminActionBody = {
+  action?: string
+  id?: number | string
+  reply?: string
+}
+
+function parseBody(rawBody: string | false | undefined): AdminActionBody {
+  if (!rawBody) {
+    return {}
+  }
+  try {
+    return JSON.parse(rawBody) as AdminActionBody
+  } catch {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid JSON body",
+    })
+  }
+}
+
+function toId(value: unknown): number | null {
+  const id = Number.parseInt(String(value), 10)
+  return Number.isFinite(id) ? id : null
+}
+
+export default defineEventHandler(async (event) => {
+  const rawBody = await readRawBody(event, "utf8").catch(() => "")
+  if (!(await verifyActivityPubAdminRequestSignature(event, rawBody || ""))) {
+    unauthorizedError()
+  }
+
+  const body = parseBody(rawBody)
+  const action = body?.action?.trim()
+  const id = toId(body?.id)
+
+  if (!action || id === null) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid request body",
+    })
+  }
+
+  if (action === "comment.delete") {
+    const deleted = await hideActivityPubCommentById(id)
+    return {
+      ok: deleted,
+      action,
+      id,
+    }
+  }
+
+  if (action === "comment.reply") {
+    const reply = typeof body?.reply === "string" ? body.reply.trim() : ""
+    if (!reply) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: "Reply text is required",
+      })
+    }
+
+    const result = await replyActivityPubCommentById(id, reply, event)
+    return {
+      ok: true,
+      action,
+      id,
+      actorId: result.actorId,
+      commentObjectId: result.commentObjectId,
+    }
+  }
+
+  if (action === "reaction.delete") {
+    const deleted = await deleteActivityPubReactionById(id)
+    return {
+      ok: deleted,
+      action,
+      id,
+    }
+  }
+
+  if (action === "follower.unfollow") {
+    const actorId = await removeFollowerById(id)
+    return {
+      ok: Boolean(actorId),
+      action,
+      id,
+      actorId,
+    }
+  }
+
+  throw createError({
+    statusCode: 400,
+    statusMessage: "Unsupported action",
+  })
+})

--- a/server/utils/activityPubAdmin.ts
+++ b/server/utils/activityPubAdmin.ts
@@ -1,4 +1,4 @@
-import { Create, isActor, Note, PUBLIC_COLLECTION } from "@fedify/vocab"
+import { Create, EmojiReact, isActor, Like, Note, PUBLIC_COLLECTION } from "@fedify/vocab"
 import { Temporal } from "@js-temporal/polyfill"
 
 import { createFedifyContext, getCloudflareEnv } from "./fedify"
@@ -303,6 +303,68 @@ export async function replyActivityPubCommentById(
   return {
     actorId: row.actor_id,
     commentObjectId: row.object_id,
+  }
+}
+
+export async function reactActivityPubCommentById(
+  id: number,
+  reactionText = "❤️",
+  event?: unknown,
+): Promise<{ actorId: string; commentObjectId: string; reaction: string; reactionType: "Like" | "EmojiReact" }> {
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const { rows } = await db.sql`SELECT actor_id, object_id
+    FROM activitypub_comments
+    WHERE id = ${id}
+      AND status = 'visible'
+    LIMIT 1`
+  const row = rows?.[0] as { actor_id?: string; object_id?: string } | undefined
+  if (!row?.actor_id || !row.object_id) {
+    throw new Error("Comment not found")
+  }
+
+  const reaction = reactionText.replace(/\s+/g, " ").trim() || "❤️"
+  const env = getDashboardEnv(event)
+  const context = await createFedifyContext(env as Parameters<typeof createFedifyContext>[0])
+  const actorUri = new URL(`/@${ACTOR_IDENTIFIER}`, SITE_ORIGIN)
+  const targetActor = new URL(row.actor_id)
+  const target = new URL(row.object_id)
+  const recipient = await context.lookupObject(targetActor)
+  if (!isActor(recipient) || !recipient.id) {
+    throw new Error("Comment actor not found")
+  }
+
+  const activity = reaction === "❤️"
+    ? new Like({
+      id: new URL(`#like-comment-${crypto.randomUUID()}`, actorUri),
+      actor: actorUri,
+      object: target,
+      to: targetActor,
+      cc: PUBLIC_COLLECTION,
+      published: Temporal.Now.instant(),
+    })
+    : new EmojiReact({
+      id: new URL(`#react-comment-${crypto.randomUUID()}`, actorUri),
+      actor: actorUri,
+      object: target,
+      content: reaction,
+      to: targetActor,
+      cc: PUBLIC_COLLECTION,
+      published: Temporal.Now.instant(),
+    })
+
+  await context.sendActivity(
+    { identifier: ACTOR_IDENTIFIER },
+    recipient,
+    activity,
+    { preferSharedInbox: true },
+  )
+
+  return {
+    actorId: row.actor_id,
+    commentObjectId: row.object_id,
+    reaction,
+    reactionType: reaction === "❤️" ? "Like" : "EmojiReact",
   }
 }
 

--- a/server/utils/activityPubAdmin.ts
+++ b/server/utils/activityPubAdmin.ts
@@ -1,0 +1,317 @@
+import { Create, isActor, Note, PUBLIC_COLLECTION } from "@fedify/vocab"
+import { Temporal } from "@js-temporal/polyfill"
+
+import { createFedifyContext, getCloudflareEnv } from "./fedify"
+import { ACTOR_IDENTIFIER, SITE_ORIGIN } from "./fedifyContent"
+import { ensureActivityPubSchema } from "./activityPubSchema"
+
+export type AdminFollowItem = {
+  id: number
+  actorId: string
+  activityId: string | null
+  status: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type AdminCommentItem = {
+  id: number
+  objectId: string
+  articlePath: string
+  actorId: string
+  actorName: string
+  actorUrl: string
+  contentText: string
+  publishedAt: string | null
+  receivedAt: string
+  status: string
+}
+
+export type AdminReactionItem = {
+  id: number
+  articlePath: string
+  actorId: string
+  actorName: string
+  actorUrl: string
+  reaction: string
+  reactionType: string
+  objectId: string
+  publishedAt: string
+  receivedAt: string
+}
+
+type CommentRow = {
+  id: number
+  object_id: string
+  article_path: string
+  actor_id: string
+  actor_name?: string | null
+  actor_url?: string | null
+  content_text: string
+  published_at?: string | null
+  received_at: string
+  status: string
+}
+
+type FollowRow = {
+  id: number
+  actor_id: string
+  activity_id: string | null
+  status: string
+  created_at: string
+  updated_at: string
+}
+
+type ReactionRow = {
+  id: number
+  article_path: string
+  actor_id: string
+  actor_name?: string | null
+  actor_url?: string | null
+  reaction: string
+  reaction_type: string
+  object_id: string
+  published_at: string
+  received_at: string
+}
+
+type DbChangeResult = {
+  changes?: unknown
+}
+
+function getDatabase() {
+  return useDatabase()
+}
+
+function normalizeRowsChanged(value: unknown): number {
+  if (typeof value === "number") {
+    return value
+  }
+  if (typeof value === "bigint") {
+    return Number(value)
+  }
+  if (typeof value === "string") {
+    return Number.parseInt(value, 10) || 0
+  }
+  return 0
+}
+
+function getDashboardEnv(env?: unknown) {
+  const eventEnv = getCloudflareEnv(env)
+  if (eventEnv) {
+    return eventEnv
+  }
+  return {
+    ...(typeof process !== "undefined" && process?.env ? process.env : {}),
+  }
+}
+
+export async function listActivityPubFollowersForAdmin(): Promise<AdminFollowItem[]> {
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const { rows } = await db.sql`SELECT
+    id,
+    actor_id,
+    activity_id,
+    status,
+    created_at,
+    updated_at
+  FROM followers
+    WHERE status IN ('accepted', 'requested')
+  ORDER BY updated_at DESC, id DESC`
+
+  return ((rows ?? []) as FollowRow[]).map((row) => ({
+    id: row.id,
+    actorId: row.actor_id,
+    activityId: row.activity_id ?? null,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }))
+}
+
+export async function listActivityPubCommentsForAdmin(options: { includeDeleted?: boolean } = {}): Promise<AdminCommentItem[]> {
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const rows = options.includeDeleted
+    ? await db.sql`SELECT
+        id,
+        object_id,
+        article_path,
+        actor_id,
+        actor_name,
+        actor_url,
+        content_text,
+        published_at,
+        received_at,
+        status
+      FROM activitypub_comments
+      ORDER BY published_at DESC, received_at DESC, id DESC`
+    : await db.sql`SELECT
+        id,
+        object_id,
+        article_path,
+        actor_id,
+        actor_name,
+        actor_url,
+        content_text,
+        published_at,
+        received_at,
+        status
+      FROM activitypub_comments
+      WHERE status = 'visible'
+      ORDER BY published_at DESC, received_at DESC, id DESC`
+
+  return ((rows.rows ?? []) as CommentRow[]).map((row) => ({
+    id: row.id,
+    objectId: row.object_id,
+    articlePath: row.article_path,
+    actorId: row.actor_id,
+    actorName: row.actor_name || row.actor_id,
+    actorUrl: row.actor_url || row.actor_id,
+    contentText: row.content_text,
+    publishedAt: row.published_at ?? null,
+    receivedAt: row.received_at,
+    status: row.status,
+  }))
+}
+
+export async function listActivityPubReactionsForAdmin(): Promise<AdminReactionItem[]> {
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const { rows } = await db.sql`SELECT
+      id,
+      article_path,
+      actor_id,
+      actor_name,
+      actor_url,
+      reaction,
+      reaction_type,
+      object_id,
+      published_at,
+      received_at
+    FROM activitypub_reactions
+    ORDER BY received_at DESC, id DESC`
+
+  return ((rows ?? []) as ReactionRow[]).map((row) => ({
+    id: row.id,
+    articlePath: row.article_path,
+    actorId: row.actor_id,
+    actorName: row.actor_name || row.actor_id,
+    actorUrl: row.actor_url || row.actor_id,
+    reaction: row.reaction,
+    reactionType: row.reaction_type,
+    objectId: row.object_id,
+    publishedAt: row.published_at,
+    receivedAt: row.received_at,
+  }))
+}
+
+export async function hideActivityPubCommentById(id: number): Promise<boolean> {
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const result = await db.sql`UPDATE activitypub_comments
+    SET status = 'deleted',
+      updated_at = CURRENT_TIMESTAMP
+    WHERE id = ${id}` as DbChangeResult
+  return normalizeRowsChanged((result as any)?.changes) > 0
+}
+
+export async function deleteActivityPubReactionById(id: number): Promise<boolean> {
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const result = await db.sql`DELETE FROM activitypub_reactions
+    WHERE id = ${id}` as DbChangeResult
+  return normalizeRowsChanged((result as any)?.changes) > 0
+}
+
+export async function removeFollowerById(id: number): Promise<string | null> {
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const row = await db.sql`SELECT actor_id
+    FROM followers
+    WHERE id = ${id}
+      AND status IN ('accepted', 'requested')
+    LIMIT 1`
+  const actorId = (row.rows?.[0] as { actor_id?: string | null } | undefined)?.actor_id ?? null
+  if (!actorId) {
+    return null
+  }
+
+  await db.sql`UPDATE followers
+    SET status = 'removed',
+      updated_at = CURRENT_TIMESTAMP
+    WHERE id = ${id}`
+
+  return actorId
+}
+
+export async function replyActivityPubCommentById(
+  id: number,
+  replyText: string,
+  event?: unknown,
+): Promise<{ actorId: string; commentObjectId: string }> {
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const { rows } = await db.sql`SELECT actor_id, object_id
+    FROM activitypub_comments
+    WHERE id = ${id}
+      AND status = 'visible'
+    LIMIT 1`
+  const row = rows?.[0] as { actor_id?: string; object_id?: string } | undefined
+  if (!row?.actor_id || !row.object_id) {
+    throw new Error("Comment not found")
+  }
+
+  const env = getDashboardEnv(event)
+  const context = await createFedifyContext(env as Parameters<typeof createFedifyContext>[0])
+  const actorUri = new URL(`/@${ACTOR_IDENTIFIER}`, SITE_ORIGIN)
+  const targetActor = new URL(row.actor_id)
+  const target = new URL(row.object_id)
+  const recipient = await context.lookupObject(targetActor)
+  if (!isActor(recipient) || !recipient.id) {
+    throw new Error("Comment actor not found")
+  }
+
+  const reply = new Note({
+    id: new URL(`#reply-${crypto.randomUUID()}`, actorUri),
+    attribution: actorUri,
+    content: replyText,
+    mediaType: "text/plain",
+    replyTarget: target,
+    to: targetActor,
+    cc: PUBLIC_COLLECTION,
+    published: Temporal.Now.instant(),
+  })
+
+  const create = new Create({
+    id: new URL(`#create-reply-${crypto.randomUUID()}`, actorUri),
+    actor: actorUri,
+    object: reply,
+    to: targetActor,
+    cc: PUBLIC_COLLECTION,
+    published: Temporal.Now.instant(),
+  })
+
+  await context.sendActivity(
+    { identifier: ACTOR_IDENTIFIER },
+    recipient,
+    create,
+    { preferSharedInbox: true },
+  )
+
+  return {
+    actorId: row.actor_id,
+    commentObjectId: row.object_id,
+  }
+}
+
+export async function getAdminDashboardData(includeDeleted = false) {
+  const [followers, comments, reactions] = await Promise.all([
+    listActivityPubFollowersForAdmin(),
+    listActivityPubCommentsForAdmin({ includeDeleted }),
+    listActivityPubReactionsForAdmin(),
+  ])
+
+  return { followers, comments, reactions }
+}

--- a/server/utils/activityPubAdminAuth.ts
+++ b/server/utils/activityPubAdminAuth.ts
@@ -170,6 +170,24 @@ async function verifyDigestHeader(event: H3Event, bodyText: string | null | unde
   return digestHeader === await createDigest(bodyText)
 }
 
+function hasSignedHeader(headers: string[], headerName: string): boolean {
+  return headers.includes(headerName.toLowerCase())
+}
+
+function hasRequiredSignedHeaders(method: string, headers: string[]): boolean {
+  if (!hasSignedHeader(headers, "(request-target)")
+    || !hasSignedHeader(headers, "host")
+    || !hasSignedHeader(headers, "date")) {
+    return false
+  }
+
+  const normalizedMethod = method.toUpperCase()
+  if (normalizedMethod === "GET" || normalizedMethod === "HEAD") {
+    return true
+  }
+  return hasSignedHeader(headers, "digest")
+}
+
 function buildSigningString(method: string, path: string, headers: string[], values: Record<string, string>): string {
   const signed = []
   for (const header of headers) {
@@ -273,7 +291,7 @@ export async function verifyActivityPubAdminRequestSignature(event: H3Event, bod
     }
 
     const headersToSign = parsed.headers
-    if (!headersToSign.includes("(request-target)")) {
+    if (!hasRequiredSignedHeaders(method, headersToSign)) {
       return false
     }
     if (!await verifyDigestHeader(event, bodyText)) {

--- a/server/utils/activityPubAdminAuth.ts
+++ b/server/utils/activityPubAdminAuth.ts
@@ -209,7 +209,6 @@ function buildSigningString(method: string, path: string, headers: string[], val
 
 function resolveSignedHeaderValues(
   event: H3Event,
-  requestUrl: URL,
   headerNames: string[],
 ): Record<string, string> {
   const rawHeaders = getRequestHeaders(event)
@@ -226,10 +225,6 @@ function resolveSignedHeaderValues(
   const values: Record<string, string> = {}
   for (const headerName of headerNames) {
     if (headerName === "(request-target)") {
-      continue
-    }
-    if (headerName === "host") {
-      values.host = requestUrl.host
       continue
     }
     const headerValue = normalized.get(headerName)
@@ -298,7 +293,7 @@ export async function verifyActivityPubAdminRequestSignature(event: H3Event, bod
       return false
     }
 
-    const values = resolveSignedHeaderValues(event, requestUrl, headersToSign)
+    const values = resolveSignedHeaderValues(event, headersToSign)
     const signedText = buildSigningString(method, path, headersToSign, {
       ...values,
       "(request-target)": `${method.toLowerCase()} ${path}`,

--- a/server/utils/activityPubAdminAuth.ts
+++ b/server/utils/activityPubAdminAuth.ts
@@ -1,0 +1,311 @@
+import {
+  createError,
+  getHeader,
+  getRequestHeaders,
+  getRequestURL,
+  type H3Event,
+} from "h3"
+
+import { ensureActivityPubSchema } from "./activityPubSchema"
+import { importPemKey } from "./auth"
+import { ACTOR_IDENTIFIER, SITE_ORIGIN } from "./fedifyContent"
+
+type SignatureFields = {
+  keyId: string
+  headers: string[]
+  signature: string
+}
+
+const DEFAULT_ADMIN_ACTOR_ID = new URL(`/@${ACTOR_IDENTIFIER}`, SITE_ORIGIN).href
+const MAX_CLOCK_SKEW_SECONDS = 300
+
+type AdminEnv = {
+  ACTIVITYPUB_ADMIN_ACTOR_ID?: string
+  ACTIVITYPUB_ADMIN_KEY_ID?: string
+  ACTIVITYPUB_ADMIN_PUBLIC_KEY?: string
+  ACTIVITYPUB_ADMIN_PUBLIC_KEYS?: string
+}
+
+function resolveAdminEnv(event?: H3Event): AdminEnv | undefined {
+  return event?.context?.cloudflare?.env
+    ?? event?.context?._platform?.cloudflare?.env
+    ?? (globalThis as any).__env__
+    ?? (typeof process !== "undefined" ? process.env : undefined)
+}
+
+function resolveAdminActorId(event: H3Event): string {
+  const env = resolveAdminEnv(event)
+  const actorIdFromEnv = env?.ACTIVITYPUB_ADMIN_ACTOR_ID?.trim()
+  if (actorIdFromEnv) {
+    return actorIdFromEnv
+  }
+
+  const keyIdFromEnv = env?.ACTIVITYPUB_ADMIN_KEY_ID?.trim()
+  if (keyIdFromEnv) {
+    return extractActorFromKeyId(keyIdFromEnv)
+  }
+
+  return DEFAULT_ADMIN_ACTOR_ID
+}
+
+function normalizeHeaderValue(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null
+  }
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : null
+}
+
+function normalizeHeaderNames(names: string[]): string[] {
+  return names.map((name) => name.trim().toLowerCase()).filter(Boolean)
+}
+
+function isDateWithinSkew(dateHeader: string | null): boolean {
+  if (!dateHeader) {
+    return false
+  }
+
+  const requestTime = Date.parse(dateHeader)
+  if (Number.isNaN(requestTime)) {
+    return false
+  }
+
+  const now = Date.now()
+  const deltaSeconds = Math.abs(now - requestTime) / 1000
+  return deltaSeconds <= MAX_CLOCK_SKEW_SECONDS
+}
+
+export function parseSignatureHeader(value: string): SignatureFields | null {
+  const keyValuePattern = /([^=\s,]+)\s*=\s*"([^"]*)"/g
+  const pairs = new Map<string, string>()
+  for (const match of value.matchAll(keyValuePattern)) {
+    const key = match[1]
+    const pairValue = match[2]
+    if (key && typeof pairValue === "string") {
+      pairs.set(key, pairValue)
+    }
+  }
+
+  const signature = pairs.get("signature") ?? ""
+  const keyId = pairs.get("keyId") ?? ""
+  const headers = normalizeHeaderNames((pairs.get("headers") ?? "").split(" "))
+  if (!signature || !keyId || headers.length === 0) {
+    return null
+  }
+  return { keyId, headers, signature }
+}
+
+function extractActorFromKeyId(value: string): string {
+  try {
+    const keyUrl = new URL(value)
+    return `${keyUrl.origin}${keyUrl.pathname}`
+  } catch {
+    return ""
+  }
+}
+
+function normalizePemFromEnv(value: string | null | undefined): string | null {
+  if (!value) {
+    return null
+  }
+  const normalized = value.replace(/\\n/g, "\n").trim()
+  return normalized || null
+}
+
+function parseConfiguredPublicKeys(value: string | null | undefined): Record<string, string> {
+  if (!value) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(value)
+    if (Array.isArray(parsed)) {
+      return Object.fromEntries(parsed
+        .filter((item) => item && typeof item.keyId === "string" && typeof item.publicKey === "string")
+        .map((item) => [item.keyId, item.publicKey]))
+    }
+    if (parsed && typeof parsed === "object") {
+      return Object.fromEntries(Object.entries(parsed)
+        .filter((entry): entry is [string, string] => typeof entry[1] === "string"))
+    }
+  } catch {
+    // Fall through to no configured keys.
+  }
+
+  return {}
+}
+
+function loadConfiguredAdminPublicKeyPem(env: AdminEnv | undefined, keyId: string): string | null {
+  const publicKeys = parseConfiguredPublicKeys(env?.ACTIVITYPUB_ADMIN_PUBLIC_KEYS)
+  const configured = publicKeys[keyId]
+  if (configured) {
+    return normalizePemFromEnv(configured)
+  }
+
+  const singleKeyId = env?.ACTIVITYPUB_ADMIN_KEY_ID?.trim() || `${DEFAULT_ADMIN_ACTOR_ID}#main-key`
+  if (singleKeyId && singleKeyId === keyId) {
+    return normalizePemFromEnv(env?.ACTIVITYPUB_ADMIN_PUBLIC_KEY)
+  }
+
+  return null
+}
+
+async function createDigest(value: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(value))
+  return `SHA-256=${Buffer.from(hashBuffer).toString("base64")}`
+}
+
+async function verifyDigestHeader(event: H3Event, bodyText: string | null | undefined): Promise<boolean> {
+  const method = (event.method || "GET").toUpperCase()
+  if (method === "GET" || method === "HEAD") {
+    return true
+  }
+
+  const digestHeader = normalizeHeaderValue(getHeader(event, "digest"))
+  if (!digestHeader || typeof bodyText !== "string") {
+    return false
+  }
+
+  return digestHeader === await createDigest(bodyText)
+}
+
+function buildSigningString(method: string, path: string, headers: string[], values: Record<string, string>): string {
+  const signed = []
+  for (const header of headers) {
+    if (header === "(request-target)") {
+      signed.push(`(request-target): ${method.toLowerCase()} ${path}`)
+      continue
+    }
+    const value = values[header]
+    if (typeof value !== "string") {
+      throw createError({
+        statusCode: 401,
+        statusMessage: "Signature header references missing header.",
+      })
+    }
+    signed.push(`${header}: ${value}`)
+  }
+  return signed.join("\n")
+}
+
+function resolveSignedHeaderValues(
+  event: H3Event,
+  requestUrl: URL,
+  headerNames: string[],
+): Record<string, string> {
+  const rawHeaders = getRequestHeaders(event)
+  const normalized = new Map<string, string>()
+  for (const [headerName, rawValue] of Object.entries(rawHeaders)) {
+    const value = Array.isArray(rawValue)
+      ? normalizeHeaderValue(rawValue.join(", "))
+      : normalizeHeaderValue(rawValue)
+    if (value) {
+      normalized.set(headerName.toLowerCase(), value)
+    }
+  }
+
+  const values: Record<string, string> = {}
+  for (const headerName of headerNames) {
+    if (headerName === "(request-target)") {
+      continue
+    }
+    if (headerName === "host") {
+      values.host = requestUrl.host
+      continue
+    }
+    const headerValue = normalized.get(headerName)
+    if (!headerValue) {
+      throw createError({
+        statusCode: 401,
+        statusMessage: `Missing required signature header: ${headerName}`,
+      })
+    }
+    values[headerName] = headerValue
+  }
+
+  return values
+}
+
+async function loadAdminPublicKeyPem(actorId: string): Promise<string | null> {
+  await ensureActivityPubSchema()
+  const db = useDatabase()
+  const { rows } = await db.sql`
+    SELECT public_key
+    FROM actor
+    WHERE actor_id = ${actorId}
+    LIMIT 1
+  `
+  return (rows?.[0] as { public_key?: string | null } | undefined)?.public_key ?? null
+}
+
+export async function verifyActivityPubAdminRequestSignature(event: H3Event, bodyText?: string): Promise<boolean> {
+  try {
+    const signatureHeader = getHeader(event, "signature")
+    if (!signatureHeader) {
+      return false
+    }
+
+    const parsed = parseSignatureHeader(signatureHeader)
+    if (!parsed) {
+      return false
+    }
+
+    const env = resolveAdminEnv(event)
+    const expectedActorId = resolveAdminActorId(event)
+    const signerActorId = extractActorFromKeyId(parsed.keyId)
+    if (!signerActorId || signerActorId !== expectedActorId) {
+      return false
+    }
+
+    const publicKeyPem = loadConfiguredAdminPublicKeyPem(env, parsed.keyId)
+      ?? await loadAdminPublicKeyPem(expectedActorId)
+    if (!publicKeyPem) {
+      return false
+    }
+
+    const requestUrl = getRequestURL(event)
+    const path = `${requestUrl.pathname}${requestUrl.search}`
+    const method = event.method || "GET"
+    const dateHeader = getHeader(event, "date") || null
+    if (!isDateWithinSkew(dateHeader)) {
+      return false
+    }
+
+    const headersToSign = parsed.headers
+    if (!headersToSign.includes("(request-target)")) {
+      return false
+    }
+    if (!await verifyDigestHeader(event, bodyText)) {
+      return false
+    }
+
+    const values = resolveSignedHeaderValues(event, requestUrl, headersToSign)
+    const signedText = buildSigningString(method, path, headersToSign, {
+      ...values,
+      "(request-target)": `${method.toLowerCase()} ${path}`,
+    })
+
+    const publicKey = await importPemKey(publicKeyPem)
+    const isValid = await crypto.subtle.verify(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        hash: { name: "SHA-256" },
+      },
+      publicKey,
+      Buffer.from(parsed.signature, "base64"),
+      new TextEncoder().encode(signedText),
+    )
+
+    return isValid
+  } catch {
+    return false
+  }
+}
+
+export function unauthorizedError() {
+  throw createError({
+    statusCode: 404,
+    statusMessage: "Not Found",
+  })
+}


### PR DESCRIPTION
## Summary

Adds a local-only ActivityPub admin workspace package and dashboard for managing remote followers, comments, likes, and emoji reactions without adding a site login flow.

## Changes

- Promotes the project to a pnpm workspace and adds the private `packages/admin` CLI package.
- Adds `pnpm admin` TUI support for browsing followers, comments, and reactions.
- Adds scriptable admin commands for automation helpers: list, reply, react to comments, delete comments/reactions, and unfollow followers.
- Adds signed admin API routes authenticated by ActivityPub-style HTTP signatures instead of admin tokens.
- Supports device key setup through local private key files and deployed public key secrets.
- Adds `.agents/skills/changkyun-admin` for safe operator-assisted ActivityPub moderation workflows.
- Moves verbose admin CLI/key management docs into `packages/admin/README.md`.

## Review Follow-up

- `eb64b80 fix: address ActivityPub admin review feedback`
  - verifies the signed `host` value against the actual request `Host` header instead of reconstructing it from `requestUrl.host`
  - hardens the admin CLI `.env` parser for quoted values, escaped newline-style sequences, `export`, trailing comments, and values containing `=`
  - replied to and resolved the moderation `Delete`/`Undo` suggestions as local hide behavior for inbound remote objects, since this actor cannot delete or undo another actor's activities

## Why

The site receives external ActivityPub interaction, but should remain login-free. This gives the site owner a local CLI/TUI path to prove ownership with a signing key and respond to or moderate ActivityPub activity.

## Security Notes

- Admin API requests require HTTP Signature authentication from the configured admin actor/key ID.
- Requests must sign `(request-target)`, `host`, and `date`; mutating requests must also sign `digest`.
- Signed `host` is checked against the actual request header.
- Private keys stay local and are ignored by git.

## Validation

- `node --check packages/admin/src/index.mjs`
- `pnpm admin --help`
- `skill-creator/scripts/quick_validate.py .agents/skills/changkyun-admin`
- `git diff --check`
- Verified signed and unsigned admin request behavior against local dev server during implementation.
- Verified signed Host/actual Host match passes and signed Host/actual Host mismatch is rejected locally.

`pnpm exec tsc --noEmit --pretty false` is still blocked by existing unrelated type errors in `app/composables/useImageSrcSet.ts`, `server/utils/auth.ts`, `server/utils/fedify.ts`, and related files.
