### PR TITLE
Fix ActivityPub admin reactions and reply threads

### DIFF
--- a/app/components/activitypub-comment-item.vue
+++ b/app/components/activitypub-comment-item.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+type CommentNode = {
+  id: number
+  objectId: string
+  actorName: string
+  actorUrl: string
+  actorIconUrl: string | null
+  contentText: string
+  url: string
+  publishedAt: string | null
+  receivedAt: string
+  replies: CommentNode[]
+}
+
+defineOptions({
+  name: 'ActivityPubCommentItem',
+})
+
+withDefaults(defineProps<{
+  comment: CommentNode
+  depth?: number
+}>(), {
+  depth: 0,
+})
+</script>
+
+<template>
+  <article class="rounded-lg border border-gray-200 p-4 dark:border-gray-800">
+    <div class="flex gap-3">
+      <NuxtLink
+        :to="comment.actorUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="mt-0.5 shrink-0"
+      >
+        <UAvatar
+          :src="comment.actorIconUrl || undefined"
+          :alt="comment.actorName"
+          size="md"
+        />
+      </NuxtLink>
+      <div class="min-w-0 flex-1 space-y-2">
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+          <NuxtLink
+            :to="comment.actorUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-medium text-gray-900 hover:underline dark:text-gray-100"
+          >
+            {{ comment.actorName }}
+          </NuxtLink>
+          <NuxtLink
+            :to="comment.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-xs text-gray-500 hover:underline"
+          >
+            <ui-datetime :datetime="comment.publishedAt || comment.receivedAt" />
+          </NuxtLink>
+        </div>
+        <p class="whitespace-pre-wrap break-words text-sm leading-relaxed text-gray-700 dark:text-gray-200">
+          {{ comment.contentText }}
+        </p>
+      </div>
+    </div>
+
+    <div
+      v-if="comment.replies.length"
+      class="mt-4 space-y-4 border-l border-gray-200 pl-4 dark:border-gray-800"
+    >
+      <ActivityPubCommentItem
+        v-for="reply in comment.replies"
+        :key="reply.objectId"
+        :comment="reply"
+        :depth="depth + 1"
+      />
+    </div>
+  </article>
+</template>

--- a/app/components/activitypub-comments.vue
+++ b/app/components/activitypub-comments.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import ActivityPubCommentItem from './activitypub-comment-item.vue'
+
 type Comment = {
   id: number
   objectId: string
@@ -7,8 +9,13 @@ type Comment = {
   actorIconUrl: string | null
   contentText: string
   url: string
+  replyTargetId: string | null
   publishedAt: string | null
   receivedAt: string
+}
+
+type CommentNode = Comment & {
+  replies: CommentNode[]
 }
 
 const props = defineProps<{
@@ -27,6 +34,33 @@ const { data, pending } = await useAsyncData(
 )
 
 const comments = computed(() => data.value?.comments ?? [])
+const threadedComments = computed<CommentNode[]>(() => {
+  const nodes = new Map<string, CommentNode>()
+  const roots: CommentNode[] = []
+
+  for (const comment of comments.value) {
+    nodes.set(comment.objectId, {
+      ...comment,
+      replies: [],
+    })
+  }
+
+  for (const comment of comments.value) {
+    const node = nodes.get(comment.objectId)
+    if (!node) {
+      continue
+    }
+
+    const parent = comment.replyTargetId ? nodes.get(comment.replyTargetId) : null
+    if (parent && parent.objectId !== node.objectId) {
+      parent.replies.push(node)
+    } else {
+      roots.push(node)
+    }
+  }
+
+  return roots
+})
 const copied = ref(false)
 let copiedResetTimer: ReturnType<typeof setTimeout> | undefined
 
@@ -87,50 +121,12 @@ onBeforeUnmount(() => {
       댓글을 불러오는 중입니다.
     </div>
 
-    <div v-else-if="comments.length" class="space-y-4">
-      <article
-        v-for="comment in comments"
+    <div v-else-if="threadedComments.length" class="space-y-4">
+      <ActivityPubCommentItem
+        v-for="comment in threadedComments"
         :key="comment.objectId"
-        class="rounded-lg border border-gray-200 p-4 dark:border-gray-800"
-      >
-        <div class="flex gap-3">
-          <NuxtLink
-            :to="comment.actorUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="mt-0.5 shrink-0"
-          >
-            <UAvatar
-              :src="comment.actorIconUrl || undefined"
-              :alt="comment.actorName"
-              size="md"
-            />
-          </NuxtLink>
-          <div class="min-w-0 flex-1 space-y-2">
-            <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-              <NuxtLink
-                :to="comment.actorUrl"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="font-medium text-gray-900 hover:underline dark:text-gray-100"
-              >
-                {{ comment.actorName }}
-              </NuxtLink>
-              <NuxtLink
-                :to="comment.url"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-xs text-gray-500 hover:underline"
-              >
-                <ui-datetime :datetime="comment.publishedAt || comment.receivedAt" />
-              </NuxtLink>
-            </div>
-            <p class="whitespace-pre-wrap break-words text-sm leading-relaxed text-gray-700 dark:text-gray-200">
-              {{ comment.contentText }}
-            </p>
-          </div>
-        </div>
-      </article>
+        :comment="comment"
+      />
     </div>
 
     <p v-else class="text-sm text-gray-500">

--- a/packages/admin/src/index.mjs
+++ b/packages/admin/src/index.mjs
@@ -727,6 +727,23 @@ async function bootstrap() {
 
   updateSectionLabel(ui.sectionLabel, state)
 
+  function renderCurrentSection(message) {
+    const listData = state[state.section]
+    if (listData.length === 0) {
+      state.selectedIndex = -1
+      ui.list.setItems(["항목이 없습니다."])
+    } else {
+      ui.list.setItems(listData.map((item) => formatRow(state.section, item)))
+      state.selectedIndex = Math.max(0, Math.min(state.selectedIndex, listData.length - 1))
+      ui.list.select(state.selectedIndex)
+    }
+
+    updateDetail(ui.detail, state.section, getSelectedItem(state, state.section, state.selectedIndex))
+    updateSectionLabel(ui.sectionLabel, state)
+    updateStatus(ui.status, message || `${SECTIONS[state.section].label} ${listData.length}개`, false)
+    ui.screen.render()
+  }
+
   async function refresh() {
     try {
       updateStatus(ui.status, `데이터 새로고침 중... (${options.baseUrl})`, false)
@@ -744,20 +761,7 @@ async function bootstrap() {
         }
       }
 
-      const listData = state[state.section]
-      if (listData.length === 0) {
-        state.selectedIndex = -1
-        ui.list.setItems(["항목이 없습니다."])
-      } else {
-        ui.list.setItems(listData.map((item) => formatRow(state.section, item)))
-        state.selectedIndex = Math.max(0, Math.min(state.selectedIndex, listData.length - 1))
-        ui.list.select(state.selectedIndex)
-      }
-
-      updateDetail(ui.detail, state.section, getSelectedItem(state, state.section, state.selectedIndex))
-      updateSectionLabel(ui.sectionLabel, state)
-      updateStatus(ui.status, `${SECTIONS[state.section].label} ${listData.length}개`, false)
-      ui.screen.render()
+      renderCurrentSection()
     } catch (error) {
       updateStatus(ui.status, String(error?.message || error), true)
       ui.screen.render()
@@ -771,7 +775,7 @@ async function bootstrap() {
     state.section = section
     state.selectedIndex = 0
     state.userSelectedSection = true
-    void refresh()
+    renderCurrentSection()
   }
 
   function applySelection(index) {

--- a/server/routes/api/admin/activitypub.post.ts
+++ b/server/routes/api/admin/activitypub.post.ts
@@ -78,6 +78,7 @@ export default defineEventHandler(async (event) => {
       id,
       actorId: result.actorId,
       commentObjectId: result.commentObjectId,
+      replyObjectId: result.replyObjectId,
     }
   }
 

--- a/server/utils/activityPubAdmin.ts
+++ b/server/utils/activityPubAdmin.ts
@@ -4,6 +4,7 @@ import { Temporal } from "@js-temporal/polyfill"
 import { createFedifyContext, getCloudflareEnv } from "./fedify"
 import { ACTOR_IDENTIFIER, SITE_ORIGIN } from "./fedifyContent"
 import { ensureActivityPubSchema } from "./activityPubSchema"
+import { persistLocalReplyComment } from "./fedifyComments"
 
 export type AdminFollowItem = {
   id: number
@@ -250,16 +251,21 @@ export async function replyActivityPubCommentById(
   id: number,
   replyText: string,
   event?: unknown,
-): Promise<{ actorId: string; commentObjectId: string }> {
+): Promise<{ actorId: string; commentObjectId: string; replyObjectId: string }> {
   await ensureActivityPubSchema()
   const db = getDatabase()
-  const { rows } = await db.sql`SELECT actor_id, object_id
+  const { rows } = await db.sql`SELECT actor_id, object_id, article_id, article_path
     FROM activitypub_comments
     WHERE id = ${id}
       AND status = 'visible'
     LIMIT 1`
-  const row = rows?.[0] as { actor_id?: string; object_id?: string } | undefined
-  if (!row?.actor_id || !row.object_id) {
+  const row = rows?.[0] as {
+    actor_id?: string
+    object_id?: string
+    article_id?: string
+    article_path?: string
+  } | undefined
+  if (!row?.actor_id || !row.object_id || !row.article_id || !row.article_path) {
     throw new Error("Comment not found")
   }
 
@@ -273,24 +279,27 @@ export async function replyActivityPubCommentById(
     throw new Error("Comment actor not found")
   }
 
+  const publishedAt = Temporal.Now.instant()
+  const replyId = new URL(`#reply-${crypto.randomUUID()}`, actorUri)
+  const createId = new URL(`#create-reply-${crypto.randomUUID()}`, actorUri)
   const reply = new Note({
-    id: new URL(`#reply-${crypto.randomUUID()}`, actorUri),
+    id: replyId,
     attribution: actorUri,
     content: replyText,
     mediaType: "text/plain",
     replyTarget: target,
     to: targetActor,
     cc: PUBLIC_COLLECTION,
-    published: Temporal.Now.instant(),
+    published: publishedAt,
   })
 
   const create = new Create({
-    id: new URL(`#create-reply-${crypto.randomUUID()}`, actorUri),
+    id: createId,
     actor: actorUri,
     object: reply,
     to: targetActor,
     cc: PUBLIC_COLLECTION,
-    published: Temporal.Now.instant(),
+    published: publishedAt,
   })
 
   await context.sendActivity(
@@ -300,9 +309,23 @@ export async function replyActivityPubCommentById(
     { preferSharedInbox: true },
   )
 
+  await persistLocalReplyComment({
+    objectId: replyId.href,
+    activityId: createId.href,
+    articleId: row.article_id,
+    articlePath: row.article_path,
+    replyTargetId: row.object_id,
+    contentText: replyText,
+    contentHtml: null,
+    url: replyId.href,
+    publishedAt: publishedAt.toString(),
+    payload: JSON.stringify(await create.toJsonLd({ format: "compact" })),
+  })
+
   return {
     actorId: row.actor_id,
     commentObjectId: row.object_id,
+    replyObjectId: replyId.href,
   }
 }
 

--- a/server/utils/activityPubSchema.ts
+++ b/server/utils/activityPubSchema.ts
@@ -1,5 +1,16 @@
 let schemaPromise: Promise<void> | null = null
 
+async function ensureActivityPubCommentsColumns(db: ReturnType<typeof useDatabase>) {
+  const { rows } = await db.sql`PRAGMA table_info(activitypub_comments);`
+  const columns = new Set((rows ?? []).map((row) => (row as { name?: string }).name).filter(Boolean))
+
+  if (!columns.has("reply_target_id")) {
+    await db.sql`ALTER TABLE activitypub_comments ADD COLUMN reply_target_id TEXT;`
+  }
+
+  await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_reply_target ON activitypub_comments(reply_target_id);`
+}
+
 async function runActivityPubSchema() {
   const db = useDatabase()
 
@@ -77,6 +88,7 @@ async function runActivityPubSchema() {
     content_text TEXT NOT NULL,
     content_html TEXT,
     url TEXT,
+    reply_target_id TEXT,
     published_at TEXT NOT NULL,
     received_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -86,6 +98,7 @@ async function runActivityPubSchema() {
   await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_activitypub_comments_object_id ON activitypub_comments(object_id);`
   await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_article_status ON activitypub_comments(article_path, status, published_at);`
   await db.sql`CREATE INDEX IF NOT EXISTS ix_activitypub_comments_actor ON activitypub_comments(actor_id);`
+  await ensureActivityPubCommentsColumns(db)
 
   await db.sql`CREATE TABLE IF NOT EXISTS activitypub_reactions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -11,6 +11,7 @@ import {
 import {
   FEDIFY_BLOG_CANONICAL_HOSTNAMES,
   FEDIFY_BLOG_COLLECTION_PREFIX,
+  ACTOR_IDENTIFIER,
   fetchFedifyContentEntry,
   normalizeArticlePath,
   SITE_ORIGIN,
@@ -28,6 +29,7 @@ export type ActivityPubComment = {
   actorIconUrl: string | null
   contentText: string
   url: string
+  replyTargetId: string | null
   publishedAt: string | null
   receivedAt: string
 }
@@ -43,6 +45,7 @@ type CommentRow = {
   actor_icon_url?: string | null
   content_text: string
   url?: string | null
+  reply_target_id?: string | null
   published_at?: string | null
   received_at: string
 }
@@ -219,6 +222,29 @@ function normalizeCommentTarget(target: URL): { articleId: string; articlePath: 
   }
 }
 
+async function resolveCommentTarget(target: URL): Promise<{ articleId: string; articlePath: string } | null> {
+  const articleTarget = normalizeCommentTarget(target)
+  if (articleTarget) {
+    return articleTarget
+  }
+
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const { rows } = await db.sql`SELECT article_id, article_path
+    FROM activitypub_comments
+    WHERE object_id = ${target.href}
+    LIMIT 1`
+  const parent = rows?.[0] as { article_id?: string | null; article_path?: string | null } | undefined
+  if (!parent?.article_id || !parent.article_path) {
+    return null
+  }
+
+  return {
+    articleId: parent.article_id,
+    articlePath: parent.article_path,
+  }
+}
+
 function isPublic(note: Note, create: Create): boolean {
   const publicHref = (PUBLIC_COLLECTION as URL).href
   const noteAudience = [...note.toIds, ...note.ccIds].map((url) => url.href)
@@ -277,7 +303,8 @@ export async function persistCommentFromCreate(ctx: { documentLoader: any; conte
     return false
   }
 
-  const target = object.replyTargetId ? normalizeCommentTarget(object.replyTargetId) : null
+  const replyTargetId = object.replyTargetId?.href ?? null
+  const target = object.replyTargetId ? await resolveCommentTarget(object.replyTargetId) : null
   if (!target) {
     return false
   }
@@ -316,6 +343,7 @@ export async function persistCommentFromCreate(ctx: { documentLoader: any; conte
     content_text,
     content_html,
     url,
+    reply_target_id,
     published_at,
     status,
     payload
@@ -331,6 +359,7 @@ export async function persistCommentFromCreate(ctx: { documentLoader: any; conte
     ${contentText},
     ${contentHtml},
     ${commentUrl},
+    ${replyTargetId},
     ${publishedAt},
     'visible',
     ${payload}
@@ -346,12 +375,80 @@ export async function persistCommentFromCreate(ctx: { documentLoader: any; conte
     content_text = excluded.content_text,
     content_html = excluded.content_html,
     url = excluded.url,
+    reply_target_id = excluded.reply_target_id,
     published_at = excluded.published_at,
     status = 'visible',
     payload = excluded.payload,
     updated_at = CURRENT_TIMESTAMP`
 
   return true
+}
+
+export async function persistLocalReplyComment(input: {
+  objectId: string
+  activityId: string | null
+  articleId: string
+  articlePath: string
+  replyTargetId: string
+  contentText: string
+  contentHtml?: string | null
+  url?: string | null
+  publishedAt: string
+  payload?: string | null
+}): Promise<void> {
+  await ensureActivityPubSchema()
+  const actorId = new URL(`/@${ACTOR_IDENTIFIER}`, SITE_ORIGIN).href
+  const db = getDatabase()
+
+  await db.sql`INSERT INTO activitypub_comments (
+    object_id,
+    activity_id,
+    article_id,
+    article_path,
+    actor_id,
+    actor_name,
+    actor_url,
+    actor_icon_url,
+    content_text,
+    content_html,
+    url,
+    reply_target_id,
+    published_at,
+    status,
+    payload
+  ) VALUES (
+    ${input.objectId},
+    ${input.activityId},
+    ${input.articleId},
+    ${input.articlePath},
+    ${actorId},
+    'Changkyun Kim',
+    ${new URL("/about", SITE_ORIGIN).href},
+    ${new URL("/image/avatar.jpg", SITE_ORIGIN).href},
+    ${input.contentText},
+    ${input.contentHtml ?? null},
+    ${input.url ?? input.objectId},
+    ${input.replyTargetId},
+    ${input.publishedAt},
+    'visible',
+    ${input.payload ?? null}
+  )
+  ON CONFLICT(object_id) DO UPDATE SET
+    activity_id = excluded.activity_id,
+    article_id = excluded.article_id,
+    article_path = excluded.article_path,
+    actor_id = excluded.actor_id,
+    actor_name = excluded.actor_name,
+    actor_url = excluded.actor_url,
+    actor_icon_url = excluded.actor_icon_url,
+    content_text = excluded.content_text,
+    content_html = excluded.content_html,
+    url = excluded.url,
+    reply_target_id = excluded.reply_target_id,
+    published_at = excluded.published_at,
+    status = 'visible',
+    payload = excluded.payload,
+    updated_at = CURRENT_TIMESTAMP`
 }
 
 export async function markCommentDeletedFromDelete(ctx: { documentLoader: any; contextLoader: any }, del: Delete): Promise<boolean> {
@@ -399,6 +496,7 @@ export async function listActivityPubComments(articlePath: string): Promise<Acti
       actor_icon_url,
       content_text,
       url,
+      reply_target_id,
       published_at,
       received_at
     FROM activitypub_comments
@@ -417,6 +515,7 @@ export async function listActivityPubComments(articlePath: string): Promise<Acti
     actorIconUrl: row.actor_icon_url || null,
     contentText: row.content_text,
     url: row.url || row.object_id,
+    replyTargetId: row.reply_target_id || null,
     publishedAt: row.published_at || null,
     receivedAt: row.received_at,
   }))


### PR DESCRIPTION
## Summary

Fixes two ActivityPub admin follow-ups from production use:

- TUI section switching no longer refetches all admin data, so `[3] 리액션` can render from the already-loaded dashboard payload instead of failing on a transient fetch.
- Admin replies to ActivityPub comments are persisted locally and rendered as threaded comments on the site.

## Changes

- Split admin TUI rendering from network refresh so section switches are local UI state changes.
- Add `reply_target_id` support for `activitypub_comments`, including runtime schema repair for existing D1 tables.
- Persist locally-authored admin replies after successful remote delivery.
- Resolve inbound replies to existing comment objects so remote replies to comment threads stay attached to the original article.
- Return `replyTargetId` from the public comments API and render nested comment threads in Vue.

## Validation

- `node --check packages/admin/src/index.mjs`
- `pnpm --silent admin list reactions --json`
- Manual TUI check: opened `pnpm admin` and switched to `[3] 리액션`
- `pnpm build`
- Local comments API call for the ActivityPub article path
- Browser check against local article page comments section
- `git diff --check HEAD~2..HEAD`

## Note

The one-off D1 backfill for the already-sent reply is intentionally not included here. It should be run only after this branch is merged and deployed, so the production schema and renderer understand `reply_target_id`.
