### PR TITLE
Fix ActivityPub reply permalinks

### DIFF
--- a/server/middleware/fedify.ts
+++ b/server/middleware/fedify.ts
@@ -85,8 +85,20 @@ function acceptsActivityPub(acceptHeader?: string | null): boolean {
     || (normalized.includes("json") && normalized.includes("profile=") && normalized.includes("activitystreams"))
 }
 
+function isPublicActivityPubDocumentRequest(method: string, pathname: string): boolean {
+  return (method === "GET" || method === "HEAD")
+    && (
+      pathname === "/@me"
+      || pathname.startsWith("/@me/replies/")
+      || (pathname.startsWith("/activitypub/replies/") && pathname.endsWith("/activity"))
+    )
+}
+
 function isFederationRequest(method: string, pathname: string, accept?: string | null): boolean {
   if ((pathname === "/inbox" || pathname === "/@me/inbox") && method === "POST") {
+    return true
+  }
+  if (isPublicActivityPubDocumentRequest(method, pathname)) {
     return true
   }
   if (pathname === "/@me" || pathname.startsWith("/@me/")) {
@@ -574,6 +586,7 @@ export default defineEventHandler(async (event) => {
   const url = getRequestURL(event)
   const fedifyUrl = toFedifyUrl(url)
   const accept = getHeader(event, "accept")
+  const forceActivityPubDocument = isPublicActivityPubDocumentRequest(event.method, fedifyUrl.pathname)
   const isFederation = isFederationRequest(event.method, fedifyUrl.pathname, accept)
   const syncTarget = resolveContentSyncTarget(url.pathname)
     ?? (isFederation ? resolveContentSyncTarget(fedifyUrl.pathname) : null)
@@ -593,6 +606,9 @@ export default defineEventHandler(async (event) => {
 
   const headers = new Headers(event.headers)
   headers.set("host", fedifyUrl.host)
+  if (forceActivityPubDocument) {
+    headers.set("accept", "application/activity+json")
+  }
 
   const body = event.method === "GET" || event.method === "HEAD"
     ? undefined

--- a/server/utils/activityPubAdmin.ts
+++ b/server/utils/activityPubAdmin.ts
@@ -4,7 +4,7 @@ import { Temporal } from "@js-temporal/polyfill"
 import { createFedifyContext, getCloudflareEnv } from "./fedify"
 import { ACTOR_IDENTIFIER, SITE_ORIGIN } from "./fedifyContent"
 import { ensureActivityPubSchema } from "./activityPubSchema"
-import { createLocalReplyPermalinks, persistLocalReplyComment } from "./fedifyComments"
+import { createLocalReplyPermalinks, persistLocalReplyActivity, persistLocalReplyComment } from "./fedifyComments"
 
 export type AdminFollowItem = {
   id: number
@@ -1067,8 +1067,7 @@ export async function replyRemoteActivityPubObject(
   const targetActorUri = normalizeRemoteUrl(target.actorId, "Search target actor id")
   const actorUri = new URL(`/@${ACTOR_IDENTIFIER}`, SITE_ORIGIN)
   const publishedAt = Temporal.Now.instant()
-  const replyId = new URL(`#reply-${crypto.randomUUID()}`, actorUri)
-  const createId = new URL(`#create-reply-${crypto.randomUUID()}`, actorUri)
+  const { objectId: replyId, activityId: createId } = createLocalReplyPermalinks()
   const replyNote = new Note({
     id: replyId,
     attribution: actorUri,
@@ -1094,6 +1093,8 @@ export async function replyRemoteActivityPubObject(
     create,
     { preferSharedInbox: true },
   )
+
+  await persistLocalReplyActivity(create)
 
   return {
     actorId: target.actorId,

--- a/server/utils/activityPubAdmin.ts
+++ b/server/utils/activityPubAdmin.ts
@@ -4,7 +4,7 @@ import { Temporal } from "@js-temporal/polyfill"
 import { createFedifyContext, getCloudflareEnv } from "./fedify"
 import { ACTOR_IDENTIFIER, SITE_ORIGIN } from "./fedifyContent"
 import { ensureActivityPubSchema } from "./activityPubSchema"
-import { persistLocalReplyComment } from "./fedifyComments"
+import { createLocalReplyPermalinks, persistLocalReplyComment } from "./fedifyComments"
 
 export type AdminFollowItem = {
   id: number
@@ -541,8 +541,7 @@ export async function replyActivityPubCommentById(
   }
 
   const publishedAt = Temporal.Now.instant()
-  const replyId = new URL(`#reply-${crypto.randomUUID()}`, actorUri)
-  const createId = new URL(`#create-reply-${crypto.randomUUID()}`, actorUri)
+  const { objectId: replyId, activityId: createId } = createLocalReplyPermalinks()
   const reply = new Note({
     id: replyId,
     attribution: actorUri,

--- a/server/utils/activityPubAdmin.ts
+++ b/server/utils/activityPubAdmin.ts
@@ -4,7 +4,13 @@ import { Temporal } from "@js-temporal/polyfill"
 import { createFedifyContext, getCloudflareEnv } from "./fedify"
 import { ACTOR_IDENTIFIER, SITE_ORIGIN } from "./fedifyContent"
 import { ensureActivityPubSchema } from "./activityPubSchema"
-import { createLocalReplyPermalinks, persistLocalReplyActivity, persistLocalReplyComment } from "./fedifyComments"
+import {
+  createLocalReplyPermalinks,
+  discardLocalReplyActivity,
+  discardLocalReplyComment,
+  persistLocalReplyActivity,
+  persistLocalReplyComment,
+} from "./fedifyComments"
 
 export type AdminFollowItem = {
   id: number
@@ -562,13 +568,6 @@ export async function replyActivityPubCommentById(
     published: publishedAt,
   })
 
-  await context.sendActivity(
-    { identifier: ACTOR_IDENTIFIER },
-    recipient,
-    create,
-    { preferSharedInbox: true },
-  )
-
   await persistLocalReplyComment({
     objectId: replyId.href,
     activityId: createId.href,
@@ -581,6 +580,20 @@ export async function replyActivityPubCommentById(
     publishedAt: publishedAt.toString(),
     payload: JSON.stringify(await create.toJsonLd({ format: "compact" })),
   })
+
+  try {
+    await context.sendActivity(
+      { identifier: ACTOR_IDENTIFIER },
+      recipient,
+      create,
+      { preferSharedInbox: true },
+    )
+  } catch (error) {
+    await discardLocalReplyComment(replyId.href).catch((cleanupError) => {
+      console.warn("Failed to discard undelivered local reply comment.", cleanupError)
+    })
+    throw error
+  }
 
   return {
     actorId: row.actor_id,
@@ -1087,14 +1100,21 @@ export async function replyRemoteActivityPubObject(
     published: publishedAt,
   })
 
-  await target.context.sendActivity(
-    { identifier: ACTOR_IDENTIFIER },
-    target.actor,
-    create,
-    { preferSharedInbox: true },
-  )
-
   await persistLocalReplyActivity(create)
+
+  try {
+    await target.context.sendActivity(
+      { identifier: ACTOR_IDENTIFIER },
+      target.actor,
+      create,
+      { preferSharedInbox: true },
+    )
+  } catch (error) {
+    await discardLocalReplyActivity(createId.href).catch((cleanupError) => {
+      console.warn("Failed to discard undelivered local reply activity.", cleanupError)
+    })
+    throw error
+  }
 
   return {
     actorId: target.actorId,

--- a/server/utils/fedify.ts
+++ b/server/utils/fedify.ts
@@ -21,6 +21,7 @@ import {
   Image,
   isActor,
   Like,
+  Note,
   Person,
   PUBLIC_COLLECTION,
   Undo,
@@ -38,6 +39,8 @@ import {
 } from "./fedifyContent"
 import packageJson from "../../package.json"
 import {
+  loadLocalReplyCreate,
+  loadLocalReplyNote,
   markCommentDeletedFromDelete,
   persistCommentFromCreate,
 } from "./fedifyComments"
@@ -515,11 +518,18 @@ builder
   })
 
 builder.setObjectDispatcher(Create, "/{collection}/{+path}/activity", async (_ctx, values) => {
-  const collection = values.collection === "blog" || values.collection === "app" ? values.collection : null
+  const collectionValue = String(values.collection ?? "")
+  const path = String(values.path ?? "").replace(/^\/+/, "")
+  const replyPrefix = "replies/"
+  if (collectionValue === "activitypub" && path.startsWith(replyPrefix)) {
+    return await loadLocalReplyCreate(path.slice(replyPrefix.length))
+  }
+
+  const collection = collectionValue === "blog" || collectionValue === "app" ? collectionValue : null
   if (!collection) {
     return null
   }
-  const entry = await fetchFedifyContentEntry(collection, `/${collection}/${values.path}`)
+  const entry = await fetchFedifyContentEntry(collection, `/${collection}/${path}`)
   return entry ? await buildCreateFromEntry(entry) : null
 })
 
@@ -530,6 +540,13 @@ builder.setObjectDispatcher(Article, "/{collection}/{+path}", async (_ctx, value
   }
   const entry = await fetchFedifyContentEntry(collection, `/${collection}/${values.path}`)
   return entry ? await buildArticleFromEntry(entry) : null
+})
+
+builder.setObjectDispatcher(Note, "/@{identifier}/replies/{id}", async (_ctx, values) => {
+  if (values.identifier !== ACTOR_IDENTIFIER || !values.id) {
+    return null
+  }
+  return await loadLocalReplyNote(String(values.id))
 })
 
 builder.setObjectDispatcher(Follow, "/@{identifier}/follow/{hash}", async (ctx, values) => {

--- a/server/utils/fedify.ts
+++ b/server/utils/fedify.ts
@@ -63,10 +63,8 @@ export type FedifyContextData = {
 const ACTOR_PATH = `/@${ACTOR_IDENTIFIER}`
 const ACTOR_URI = new URL(ACTOR_PATH, SITE_ORIGIN)
 const SHARED_INBOX_URI = new URL("/inbox", SITE_ORIGIN)
-const OUTBOX_POST_OBJECT_PATTERNS = [
-  new URL("/blog/%", SITE_ORIGIN).href,
-  new URL("/app/%", SITE_ORIGIN).href,
-]
+const OUTBOX_BLOG_POST_OBJECT_PATTERN = new URL("/blog/%", SITE_ORIGIN).href
+const OUTBOX_APP_POST_OBJECT_PATTERN = new URL("/app/%", SITE_ORIGIN).href
 const memoryKv = new MemoryKvStore()
 
 function importPemKey(pem: string, usage: KeyUsage[]): Promise<CryptoKey> {
@@ -192,7 +190,10 @@ async function countLocalPosts(): Promise<number> {
       FROM activity
       WHERE direction = 'outbox'
         AND type = 'Create'
-        AND (object LIKE ${OUTBOX_POST_OBJECT_PATTERNS[0]} OR object LIKE ${OUTBOX_POST_OBJECT_PATTERNS[1]})`
+        AND (
+          object LIKE ${OUTBOX_BLOG_POST_OBJECT_PATTERN}
+          OR object LIKE ${OUTBOX_APP_POST_OBJECT_PATTERN}
+        )`
     return countValue((rows?.[0] as Record<string, unknown> | undefined)?.count)
   } catch {
     console.warn("Failed to count ActivityPub local posts from outbox; using 0.")

--- a/server/utils/fedify.ts
+++ b/server/utils/fedify.ts
@@ -63,6 +63,10 @@ export type FedifyContextData = {
 const ACTOR_PATH = `/@${ACTOR_IDENTIFIER}`
 const ACTOR_URI = new URL(ACTOR_PATH, SITE_ORIGIN)
 const SHARED_INBOX_URI = new URL("/inbox", SITE_ORIGIN)
+const OUTBOX_POST_OBJECT_PATTERNS = [
+  new URL("/blog/%", SITE_ORIGIN).href,
+  new URL("/app/%", SITE_ORIGIN).href,
+]
 const memoryKv = new MemoryKvStore()
 
 function importPemKey(pem: string, usage: KeyUsage[]): Promise<CryptoKey> {
@@ -184,7 +188,11 @@ async function countLocalPosts(): Promise<number> {
   try {
     await ensureActivityPubSchema()
     const db = getDatabase()
-    const { rows } = await db.sql`SELECT COUNT(*) AS count FROM activity WHERE direction = 'outbox' AND type = 'Create'`
+    const { rows } = await db.sql`SELECT COUNT(*) AS count
+      FROM activity
+      WHERE direction = 'outbox'
+        AND type = 'Create'
+        AND (object LIKE ${OUTBOX_POST_OBJECT_PATTERNS[0]} OR object LIKE ${OUTBOX_POST_OBJECT_PATTERNS[1]})`
     return countValue((rows?.[0] as Record<string, unknown> | undefined)?.count)
   } catch {
     console.warn("Failed to count ActivityPub local posts from outbox; using 0.")

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -566,6 +566,14 @@ export async function persistLocalReplyComment(input: {
     updated_at = CURRENT_TIMESTAMP`
 }
 
+export async function discardLocalReplyComment(objectId: string): Promise<void> {
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  await db.sql`DELETE FROM activitypub_comments
+    WHERE object_id = ${objectId}
+      AND actor_id = ${ACTOR_URI.href}`
+}
+
 export async function persistLocalReplyActivity(create: Create): Promise<void> {
   const activityId = create.id?.href
   const objectId = create.objectId?.href
@@ -599,6 +607,16 @@ export async function persistLocalReplyActivity(create: Create): Promise<void> {
     payload = excluded.payload,
     direction = 'outbox',
     updated_at = CURRENT_TIMESTAMP`
+}
+
+export async function discardLocalReplyActivity(activityId: string): Promise<void> {
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  await db.sql`DELETE FROM activity
+    WHERE activity_id = ${activityId}
+      AND actor_id = ${ACTOR_URI.href}
+      AND type = 'Create'
+      AND direction = 'outbox'`
 }
 
 async function loadLocalReplyObjectRow(replyId: string): Promise<LocalReplyObjectRow | null> {

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -7,6 +7,7 @@ import {
   Note,
   PUBLIC_COLLECTION,
 } from "@fedify/vocab"
+import { Temporal } from "@js-temporal/polyfill"
 
 import {
   FEDIFY_BLOG_CANONICAL_HOSTNAMES,
@@ -52,9 +53,75 @@ type CommentRow = {
 
 const SITE_HOST = new URL(SITE_ORIGIN).host.toLowerCase()
 const BLOG_HOSTS = new Set(Array.from(FEDIFY_BLOG_CANONICAL_HOSTNAMES, (host) => host.toLowerCase()))
+const ACTOR_URI = new URL(`/@${ACTOR_IDENTIFIER}`, SITE_ORIGIN)
+const LOCAL_REPLY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+type LocalReplyObjectRow = {
+  object_id: string
+  activity_id?: string | null
+  content_text: string
+  content_html?: string | null
+  reply_target_id?: string | null
+  published_at?: string | null
+  target_actor_id?: string | null
+}
 
 function getDatabase() {
   return useDatabase()
+}
+
+function normalizeLocalReplyId(value: string): string | null {
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(value)
+  } catch {
+    return null
+  }
+  return LOCAL_REPLY_ID_PATTERN.test(decoded) ? decoded : null
+}
+
+function localReplyObjectHref(replyId: string): string | null {
+  const normalized = normalizeLocalReplyId(replyId)
+  return normalized ? new URL(`/@${ACTOR_IDENTIFIER}/replies/${normalized}`, SITE_ORIGIN).href : null
+}
+
+function localReplyActivityHref(replyId: string): string | null {
+  const normalized = normalizeLocalReplyId(replyId)
+  return normalized ? new URL(`/activitypub/replies/${normalized}/activity`, SITE_ORIGIN).href : null
+}
+
+export function createLocalReplyPermalinks(replyId = crypto.randomUUID()): { objectId: URL; activityId: URL } {
+  const objectHref = localReplyObjectHref(replyId)
+  const activityHref = localReplyActivityHref(replyId)
+  if (!objectHref || !activityHref) {
+    throw new Error("Invalid local reply id")
+  }
+  return {
+    objectId: new URL(objectHref),
+    activityId: new URL(activityHref),
+  }
+}
+
+function parseUrl(value?: string | null): URL | null {
+  if (!value) {
+    return null
+  }
+  try {
+    return new URL(value)
+  } catch {
+    return null
+  }
+}
+
+function parseInstant(value?: string | null): Temporal.Instant | null {
+  if (!value) {
+    return null
+  }
+  try {
+    return Temporal.Instant.from(value)
+  } catch {
+    return null
+  }
 }
 
 function stringifyLanguageValue(value: unknown): string {
@@ -449,6 +516,86 @@ export async function persistLocalReplyComment(input: {
     status = 'visible',
     payload = excluded.payload,
     updated_at = CURRENT_TIMESTAMP`
+}
+
+async function loadLocalReplyObjectRow(replyId: string): Promise<LocalReplyObjectRow | null> {
+  const objectHref = localReplyObjectHref(replyId)
+  if (!objectHref) {
+    return null
+  }
+
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const { rows } = await db.sql`SELECT
+      reply.object_id,
+      reply.activity_id,
+      reply.content_text,
+      reply.content_html,
+      reply.reply_target_id,
+      reply.published_at,
+      parent.actor_id AS target_actor_id
+    FROM activitypub_comments reply
+    LEFT JOIN activitypub_comments parent
+      ON parent.object_id = reply.reply_target_id
+    WHERE reply.object_id = ${objectHref}
+      AND reply.actor_id = ${ACTOR_URI.href}
+      AND reply.status = 'visible'
+    LIMIT 1`
+
+  const row = rows?.[0] as LocalReplyObjectRow | undefined
+  return row?.object_id && row.content_text ? row : null
+}
+
+function buildLocalReplyNote(row: LocalReplyObjectRow): Note | null {
+  const objectId = parseUrl(row.object_id)
+  const replyTarget = parseUrl(row.reply_target_id)
+  if (!objectId || !replyTarget) {
+    return null
+  }
+
+  const targetActor = parseUrl(row.target_actor_id)
+  const published = parseInstant(row.published_at)
+  const content = row.content_html || row.content_text
+
+  return new Note({
+    id: objectId,
+    attribution: ACTOR_URI,
+    content,
+    mediaType: row.content_html ? "text/html" : "text/plain",
+    replyTarget,
+    ...(targetActor ? { to: targetActor } : {}),
+    cc: PUBLIC_COLLECTION,
+    ...(published ? { published } : {}),
+  })
+}
+
+export async function loadLocalReplyNote(replyId: string): Promise<Note | null> {
+  const row = await loadLocalReplyObjectRow(replyId)
+  return row ? buildLocalReplyNote(row) : null
+}
+
+export async function loadLocalReplyCreate(replyId: string): Promise<Create | null> {
+  const row = await loadLocalReplyObjectRow(replyId)
+  if (!row) {
+    return null
+  }
+
+  const note = buildLocalReplyNote(row)
+  const activityId = parseUrl(row.activity_id) ?? parseUrl(localReplyActivityHref(replyId))
+  if (!note || !activityId) {
+    return null
+  }
+
+  const targetActor = parseUrl(row.target_actor_id)
+  const published = parseInstant(row.published_at)
+  return new Create({
+    id: activityId,
+    actor: ACTOR_URI,
+    object: note,
+    ...(targetActor ? { to: targetActor } : {}),
+    cc: PUBLIC_COLLECTION,
+    ...(published ? { published } : {}),
+  })
 }
 
 export async function markCommentDeletedFromDelete(ctx: { documentLoader: any; contextLoader: any }, del: Delete): Promise<boolean> {

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -66,6 +66,12 @@ type LocalReplyObjectRow = {
   target_actor_id?: string | null
 }
 
+type LocalReplyActivityRow = {
+  activity_id: string
+  object?: string | null
+  payload?: string | null
+}
+
 function getDatabase() {
   return useDatabase()
 }
@@ -119,6 +125,48 @@ function parseInstant(value?: string | null): Temporal.Instant | null {
   }
   try {
     return Temporal.Instant.from(value)
+  } catch {
+    return null
+  }
+}
+
+function firstPayloadUrl(value: unknown): URL | null {
+  if (!value) {
+    return null
+  }
+  if (typeof value === "string") {
+    return parseUrl(value)
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const url = firstPayloadUrl(item)
+      if (url) {
+        return url
+      }
+    }
+    return null
+  }
+  if (typeof value === "object") {
+    const candidate = value as { id?: unknown; href?: unknown }
+    if (typeof candidate.id === "string") {
+      return parseUrl(candidate.id)
+    }
+    if (typeof candidate.href === "string") {
+      return parseUrl(candidate.href)
+    }
+  }
+  return null
+}
+
+function parsePayloadObject(value?: string | null): Record<string, unknown> | null {
+  if (!value) {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(value)
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
   } catch {
     return null
   }
@@ -518,6 +566,41 @@ export async function persistLocalReplyComment(input: {
     updated_at = CURRENT_TIMESTAMP`
 }
 
+export async function persistLocalReplyActivity(create: Create): Promise<void> {
+  const activityId = create.id?.href
+  const objectId = create.objectId?.href
+  if (!activityId || !objectId) {
+    throw new Error("Cannot persist local reply activity without id and object id.")
+  }
+
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const payload = JSON.stringify(await create.toJsonLd({ format: "compact" }))
+
+  await db.sql`INSERT INTO activity (
+    activity_id,
+    actor_id,
+    type,
+    object,
+    payload,
+    direction
+  ) VALUES (
+    ${activityId},
+    ${ACTOR_URI.href},
+    'Create',
+    ${objectId},
+    ${payload},
+    'outbox'
+  )
+  ON CONFLICT(activity_id) DO UPDATE SET
+    actor_id = excluded.actor_id,
+    type = excluded.type,
+    object = excluded.object,
+    payload = excluded.payload,
+    direction = 'outbox',
+    updated_at = CURRENT_TIMESTAMP`
+}
+
 async function loadLocalReplyObjectRow(replyId: string): Promise<LocalReplyObjectRow | null> {
   const objectHref = localReplyObjectHref(replyId)
   if (!objectHref) {
@@ -546,6 +629,27 @@ async function loadLocalReplyObjectRow(replyId: string): Promise<LocalReplyObjec
   return row?.object_id && row.content_text ? row : null
 }
 
+async function loadLocalReplyActivityRow(replyId: string): Promise<LocalReplyActivityRow | null> {
+  const objectHref = localReplyObjectHref(replyId)
+  const activityHref = localReplyActivityHref(replyId)
+  if (!objectHref || !activityHref) {
+    return null
+  }
+
+  await ensureActivityPubSchema()
+  const db = getDatabase()
+  const { rows } = await db.sql`SELECT activity_id, object, payload
+    FROM activity
+    WHERE activity_id = ${activityHref}
+      AND object = ${objectHref}
+      AND actor_id = ${ACTOR_URI.href}
+      AND type = 'Create'
+      AND direction = 'outbox'
+    LIMIT 1`
+  const row = rows?.[0] as LocalReplyActivityRow | undefined
+  return row?.activity_id && row.payload ? row : null
+}
+
 function buildLocalReplyNote(row: LocalReplyObjectRow): Note | null {
   const objectId = parseUrl(row.object_id)
   const replyTarget = parseUrl(row.reply_target_id)
@@ -569,25 +673,85 @@ function buildLocalReplyNote(row: LocalReplyObjectRow): Note | null {
   })
 }
 
+function buildLocalReplyNoteFromActivity(row: LocalReplyActivityRow): Note | null {
+  const payload = parsePayloadObject(row.payload)
+  const object = payload?.object
+  if (!object || typeof object !== "object" || Array.isArray(object)) {
+    return null
+  }
+
+  const note = object as Record<string, unknown>
+  const objectId = firstPayloadUrl(note.id)
+  const replyTarget = firstPayloadUrl(note.inReplyTo)
+  const content = stringifyLanguageValue(note.content)
+  if (!objectId || !replyTarget || !content) {
+    return null
+  }
+
+  const targetActor = firstPayloadUrl(note.to) ?? firstPayloadUrl(payload.to)
+  const published = parseInstant(
+    typeof note.published === "string"
+      ? note.published
+      : typeof payload.published === "string"
+        ? payload.published
+        : null,
+  )
+  const mediaType = typeof note.mediaType === "string" ? note.mediaType : "text/plain"
+
+  return new Note({
+    id: objectId,
+    attribution: ACTOR_URI,
+    content,
+    mediaType,
+    replyTarget,
+    ...(targetActor ? { to: targetActor } : {}),
+    cc: PUBLIC_COLLECTION,
+    ...(published ? { published } : {}),
+  })
+}
+
 export async function loadLocalReplyNote(replyId: string): Promise<Note | null> {
   const row = await loadLocalReplyObjectRow(replyId)
-  return row ? buildLocalReplyNote(row) : null
+  if (row) {
+    return buildLocalReplyNote(row)
+  }
+  const activityRow = await loadLocalReplyActivityRow(replyId)
+  return activityRow ? buildLocalReplyNoteFromActivity(activityRow) : null
 }
 
 export async function loadLocalReplyCreate(replyId: string): Promise<Create | null> {
   const row = await loadLocalReplyObjectRow(replyId)
-  if (!row) {
-    return null
+  if (row) {
+    const note = buildLocalReplyNote(row)
+    const activityId = parseUrl(row.activity_id) ?? parseUrl(localReplyActivityHref(replyId))
+    if (!note || !activityId) {
+      return null
+    }
+
+    const targetActor = parseUrl(row.target_actor_id)
+    const published = parseInstant(row.published_at)
+    return new Create({
+      id: activityId,
+      actor: ACTOR_URI,
+      object: note,
+      ...(targetActor ? { to: targetActor } : {}),
+      cc: PUBLIC_COLLECTION,
+      ...(published ? { published } : {}),
+    })
   }
 
-  const note = buildLocalReplyNote(row)
-  const activityId = parseUrl(row.activity_id) ?? parseUrl(localReplyActivityHref(replyId))
-  if (!note || !activityId) {
+  const activityRow = await loadLocalReplyActivityRow(replyId)
+  if (!activityRow) {
     return null
   }
-
-  const targetActor = parseUrl(row.target_actor_id)
-  const published = parseInstant(row.published_at)
+  const note = buildLocalReplyNoteFromActivity(activityRow)
+  const payload = parsePayloadObject(activityRow.payload)
+  const activityId = parseUrl(activityRow.activity_id)
+  if (!note || !payload || !activityId) {
+    return null
+  }
+  const targetActor = firstPayloadUrl(payload.to)
+  const published = parseInstant(typeof payload.published === "string" ? payload.published : null)
   return new Create({
     id: activityId,
     actor: ACTOR_URI,

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -64,6 +64,7 @@ type LocalReplyObjectRow = {
   reply_target_id?: string | null
   published_at?: string | null
   target_actor_id?: string | null
+  payload?: string | null
 }
 
 type LocalReplyActivityRow = {
@@ -634,6 +635,7 @@ async function loadLocalReplyObjectRow(replyId: string): Promise<LocalReplyObjec
       reply.content_html,
       reply.reply_target_id,
       reply.published_at,
+      reply.payload,
       parent.actor_id AS target_actor_id
     FROM activitypub_comments reply
     LEFT JOIN activitypub_comments parent
@@ -691,7 +693,44 @@ function buildLocalReplyNote(row: LocalReplyObjectRow): Note | null {
   })
 }
 
-function buildLocalReplyNoteFromActivity(row: LocalReplyActivityRow): Note | null {
+async function parseLocalReplyCreateFromPayload(row: {
+  activity_id?: string | null
+  object?: string | null
+  payload?: string | null
+}): Promise<Create | null> {
+  const payload = parsePayloadObject(row.payload)
+  if (!payload) {
+    return null
+  }
+
+  try {
+    const create = await Create.fromJsonLd(payload)
+    const activityId = parseUrl(row.activity_id)
+    const objectId = parseUrl(row.object)
+    if (activityId && create.id?.href !== activityId.href) {
+      return null
+    }
+    if (objectId && create.objectId?.href !== objectId.href) {
+      return null
+    }
+    if (!create.actorIds.some((actorId) => actorId.href === ACTOR_URI.href)) {
+      return null
+    }
+    return create
+  } catch {
+    return null
+  }
+}
+
+async function buildLocalReplyNoteFromActivity(row: LocalReplyActivityRow): Promise<Note | null> {
+  const create = await parseLocalReplyCreateFromPayload(row)
+  if (create) {
+    const object = await create.getObject({ suppressError: true })
+    if (object instanceof Note) {
+      return object
+    }
+  }
+
   const payload = parsePayloadObject(row.payload)
   const object = payload?.object
   if (!object || typeof object !== "object" || Array.isArray(object)) {
@@ -731,15 +770,36 @@ function buildLocalReplyNoteFromActivity(row: LocalReplyActivityRow): Note | nul
 export async function loadLocalReplyNote(replyId: string): Promise<Note | null> {
   const row = await loadLocalReplyObjectRow(replyId)
   if (row) {
+    if (row.payload) {
+      const note = await buildLocalReplyNoteFromActivity({
+        activity_id: row.activity_id ?? null,
+        object: row.object_id,
+        payload: row.payload,
+      })
+      if (note) {
+        return note
+      }
+    }
     return buildLocalReplyNote(row)
   }
   const activityRow = await loadLocalReplyActivityRow(replyId)
-  return activityRow ? buildLocalReplyNoteFromActivity(activityRow) : null
+  return activityRow ? await buildLocalReplyNoteFromActivity(activityRow) : null
 }
 
 export async function loadLocalReplyCreate(replyId: string): Promise<Create | null> {
   const row = await loadLocalReplyObjectRow(replyId)
   if (row) {
+    if (row.payload) {
+      const create = await parseLocalReplyCreateFromPayload({
+        activity_id: row.activity_id ?? null,
+        object: row.object_id,
+        payload: row.payload,
+      })
+      if (create) {
+        return create
+      }
+    }
+
     const note = buildLocalReplyNote(row)
     const activityId = parseUrl(row.activity_id) ?? parseUrl(localReplyActivityHref(replyId))
     if (!note || !activityId) {
@@ -762,7 +822,12 @@ export async function loadLocalReplyCreate(replyId: string): Promise<Create | nu
   if (!activityRow) {
     return null
   }
-  const note = buildLocalReplyNoteFromActivity(activityRow)
+  const create = await parseLocalReplyCreateFromPayload(activityRow)
+  if (create) {
+    return create
+  }
+
+  const note = await buildLocalReplyNoteFromActivity(activityRow)
   const payload = parsePayloadObject(activityRow.payload)
   const activityId = parseUrl(activityRow.activity_id)
   if (!note || !payload || !activityId) {


### PR DESCRIPTION
## Summary
- Replace fragment-based local reply ids with dereferenceable ActivityPub reply document URLs.
- Add dispatchers/loaders so local reply Note and Create documents can be fetched from the permalink URLs.
- Persist reply permalink documents before delivery and clean them up if delivery fails.
- Keep reply Create rows out of the NodeInfo local-post fallback count.
- Address Gemini review feedback by preferring stored JSON-LD payloads when reconstructing reply documents and by clarifying outbox post-count patterns.

## Why
Remote servers receive the reply object id, but URL fragments are never sent to the server and `/@me` did not have a GET document endpoint. That made delivered reply links inaccessible and propagated broken permalinks to remote readers.

## Review follow-up commits
- `e8bf456 fix: restore replies from stored payloads`
- `cae28ca fix: clarify outbox post count patterns`

## Validation
- `pnpm build`
