### PR TITLE
fix: preserve incoming emoji reactions

### DIFF
--- a/server/utils/fedifyReactions.ts
+++ b/server/utils/fedifyReactions.ts
@@ -43,6 +43,7 @@ type ReactionActorRow = {
 }
 
 type ReactionActivity = Like | EmojiReact
+type ReactionValueContext = { documentLoader: any; contextLoader: any }
 
 const HEART_REACTION = "❤️"
 const SITE_HOST = new URL(SITE_ORIGIN).host.toLowerCase()
@@ -100,6 +101,61 @@ function normalizeReactionValue(value: string): string | null {
     return null
   }
   return reaction
+}
+
+function firstReactionText(...values: unknown[]): string | null {
+  for (const value of values) {
+    const reaction = normalizeReactionValue(stringifyLanguageValue(value))
+    if (reaction) {
+      return reaction
+    }
+  }
+  return null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !(value instanceof URL)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function firstJsonLdReactionValue(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const reaction = firstJsonLdReactionValue(item)
+      if (reaction) {
+        return reaction
+      }
+    }
+    return null
+  }
+
+  const record = asRecord(value)
+  if (!record) {
+    return firstReactionText(value)
+  }
+
+  const directReaction = firstReactionText(record.content, record.name)
+  if (directReaction) {
+    return directReaction
+  }
+
+  return firstJsonLdReactionValue(record.tag)
+}
+
+async function getReactionTagValue(ctx: ReactionValueContext, reaction: ReactionActivity): Promise<string | null> {
+  for await (const tag of reaction.getTags({
+    documentLoader: ctx.documentLoader,
+    contextLoader: ctx.contextLoader,
+    suppressError: true,
+  })) {
+    const tagRecord = asRecord(tag)
+    const tagReaction = firstReactionText(tagRecord?.content, tagRecord?.name)
+    if (tagReaction) {
+      return tagReaction
+    }
+  }
+  return null
 }
 
 function normalizeReactionTarget(target: URL): { articleId: string; articlePath: string; objectId: string } | null {
@@ -197,14 +253,18 @@ async function resolveReactionActor(ctx: { documentLoader: any; contextLoader: a
   return isActor(actor) ? await resolveActorProfile(ctx, actor) : null
 }
 
-function getReactionValue(reaction: ReactionActivity): string | null {
+async function getReactionValue(
+  ctx: ReactionValueContext,
+  reaction: ReactionActivity,
+  payloadJsonLd: unknown,
+): Promise<string | null> {
   if (reaction instanceof Like) {
     return HEART_REACTION
   }
-  return normalizeReactionValue(
-    stringifyLanguageValue(reaction.content)
-    || stringifyLanguageValue(reaction.name),
-  )
+
+  return firstReactionText(reaction.content, reaction.name)
+    ?? await getReactionTagValue(ctx, reaction)
+    ?? firstJsonLdReactionValue(payloadJsonLd)
 }
 
 export async function persistReactionFromActivity(
@@ -221,14 +281,15 @@ export async function persistReactionFromActivity(
   }
 
   const actor = await resolveReactionActor(ctx, reaction)
-  const reactionValue = getReactionValue(reaction)
+  const payloadJsonLd = await reaction.toJsonLd({ format: "compact" })
+  const reactionValue = await getReactionValue(ctx, reaction, payloadJsonLd)
   if (!actor || !reactionValue) {
     return false
   }
 
   await ensureActivityPubSchema()
   const db = getDatabase()
-  const payload = JSON.stringify(await reaction.toJsonLd({ format: "compact" }))
+  const payload = JSON.stringify(payloadJsonLd)
   const publishedAt = reaction.published?.toString() ?? new Date().toISOString()
   const activityId = reaction.id?.href ?? null
   const reactionType = reaction instanceof Like ? "Like" : "EmojiReact"

--- a/server/utils/fedifyReactions.ts
+++ b/server/utils/fedifyReactions.ts
@@ -114,7 +114,7 @@ function firstReactionText(...values: unknown[]): string | null {
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !(value instanceof URL)
+  return value && typeof value === "object" && !Array.isArray(value) && !(value instanceof URL)
     ? value as Record<string, unknown>
     : null
 }
@@ -140,7 +140,7 @@ function firstJsonLdReactionValue(value: unknown): string | null {
     return directReaction
   }
 
-  return firstJsonLdReactionValue(record.tag)
+  return record.tag ? firstJsonLdReactionValue(record.tag) : null
 }
 
 async function getReactionTagValue(ctx: ReactionValueContext, reaction: ReactionActivity): Promise<string | null> {


### PR DESCRIPTION
## Changes

- Keeps `Like` activities generalized as the heart reaction.
- Preserves non-heart `EmojiReact` values from `content` or `name`.
- Adds fallback extraction from emoji `tag` data and compact JSON-LD so future incoming reactions keep the actual emoji instead of collapsing to heart.
- Tightens JSON-LD parsing guards after review by excluding arrays from record casts and avoiding missing-tag recursion.

## Why

Incoming emoji reactions can arrive with the actual emoji in shapes other than top-level `content`/`name`. The previous normalization path only read those top-level fields, so non-heart emoji reactions were not reliably preserved at storage time.

## Commits

- `b9ecbb0` fix: preserve incoming emoji reactions
- `f49b4d9` fix: tighten reaction JSON-LD parsing guards

## Validation

- `pnpm typecheck`
- `pnpm lint`
- Fedify sample check for `Like`, `EmojiReact.content`, and `EmojiReact.tag` payload shapes
