### PR TITLE
Update Fedify packages to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@fedify/cfworkers": "2.2.1",
-    "@fedify/fedify": "2.2.1",
-    "@fedify/vocab": "2.2.1",
+    "@fedify/cfworkers": "2.3.0",
+    "@fedify/fedify": "2.3.0",
+    "@fedify/vocab": "2.3.0",
     "@js-temporal/polyfill": "0.5.1",
     "@nuxt/content": "3.13.0",
     "@nuxt/image": "^2.0.0",
@@ -39,7 +39,8 @@
     "nuxt": "^4.4.7"
   },
   "devDependencies": {
-    "@fedify/testing": "2.2.1",
+    "@cloudflare/workers-types": "4.20260625.1",
+    "@fedify/testing": "2.3.0",
     "@iconify-json/lucide": "^1.2.105",
     "@nuxt/eslint": "^1.15.2",
     "@types/negotiator": "^0.6.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,14 +13,14 @@ importers:
   .:
     dependencies:
       '@fedify/cfworkers':
-        specifier: 2.2.1
-        version: 2.2.1(@cloudflare/workers-types@4.20260507.1)(@fedify/fedify@2.2.1)
+        specifier: 2.3.0
+        version: 2.3.0(@cloudflare/workers-types@4.20260625.1)(@fedify/fedify@2.3.0)
       '@fedify/fedify':
-        specifier: 2.2.1
-        version: 2.2.1
+        specifier: 2.3.0
+        version: 2.3.0
       '@fedify/vocab':
-        specifier: 2.2.1
-        version: 2.2.1
+        specifier: 2.3.0
+        version: 2.3.0
       '@js-temporal/polyfill':
         specifier: 0.5.1
         version: 0.5.1
@@ -64,9 +64,12 @@ importers:
         specifier: ^4.4.7
         version: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 4.20260625.1
+        version: 4.20260625.1
       '@fedify/testing':
-        specifier: 2.2.1
-        version: 2.2.1(@fedify/fedify@2.2.1)
+        specifier: 2.3.0
+        version: 2.3.0(@fedify/fedify@2.3.0)
       '@iconify-json/lucide':
         specifier: ^1.2.105
         version: 1.2.105
@@ -99,7 +102,7 @@ importers:
         version: 5.9.3
       wrangler:
         specifier: ^4.90.0
-        version: 4.90.0(@cloudflare/workers-types@4.20260507.1)
+        version: 4.90.0(@cloudflare/workers-types@4.20260625.1)
 
   packages/admin:
     dependencies:
@@ -769,8 +772,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260507.1':
-    resolution: {integrity: sha512-QChtMFu8EeVKaL4dW5r5wfZzlbH5CUnZU5Ef6E1cPjXzqryQuCwmEDNr+Oj2obbKR9jsVIUHPF/pkFaKWdYl2g==}
+  '@cloudflare/workers-types@4.20260625.1':
+    resolution: {integrity: sha512-asH0RhPHiNu/IUSssyiOJYAcGqysy0DJpO9fihC6KATaayD9CE1E9bgNQozTLUraxrCT2qkM4CBOIcV0M5NPJw==}
 
   '@colordx/core@5.4.3':
     resolution: {integrity: sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==}
@@ -1340,35 +1343,39 @@ packages:
   '@fastify/accept-negotiator@2.0.1':
     resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
 
-  '@fedify/cfworkers@2.2.1':
-    resolution: {integrity: sha512-mJniCbAAkF0b97OxJd0krUDxKqTOyF0ReytMzUWVlf4OknKvsxcnYs2NrfD3toegH8FW2ljCUBzawYlaeNJCZA==}
+  '@fedify/cfworkers@2.3.0':
+    resolution: {integrity: sha512-DDrTH7x9oO4Ug78s0SHOTv0rqQ0YCGftp1p/HU6mlr3d69K0vA7MdHZgmfsxkWUv4EL6HuBky5VdJe7swjH11A==}
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20250906.0
-      '@fedify/fedify': ^2.2.1
+      '@cloudflare/workers-types': ^4.20260511.1
+      '@fedify/fedify': ^2.3.0
 
-  '@fedify/fedify@2.2.1':
-    resolution: {integrity: sha512-OIxa7+Kp6KDpz8v6bgo67Zg8fWRNdyNbOx21WrJbPhh6RaSl7SkVm1GAQ2ehIS318ipoFUD00DvM6sKbcR+DYg==}
+  '@fedify/fedify@2.3.0':
+    resolution: {integrity: sha512-lVSuHbp5xYco8FOZnR6dZaFo2w4FMn2+cba+OiAGjxPoWsdn5+gKrMXXuwGD37qWBILEuDGGqCy987WaytbI/A==}
     engines: {bun: '>=1.1.0', deno: '>=2.0.0', node: '>=22.0.0'}
 
-  '@fedify/testing@2.2.1':
-    resolution: {integrity: sha512-ocV4vldAl8fKnGBgF8c1Iu7JFbjc3p8V2O2bbHOgurUrbz+m3GhLEUZUiTO/4XapsrFvjD3hLo9AmBBjCVqJEw==}
+  '@fedify/testing@2.3.0':
+    resolution: {integrity: sha512-QuZI7sucl8ZPjtGpNkob0tGg+w+K73In9cF2mEh1SUsmLqqjZyTPcr3JXr9KsH0bX8YZxit0hzchJIoTZcYHTw==}
     peerDependencies:
-      '@fedify/fedify': ^2.2.1
+      '@fedify/fedify': ^2.3.0
 
-  '@fedify/vocab-runtime@2.2.1':
-    resolution: {integrity: sha512-NRnlhUv2mmVGNMrjhmTUMN1gZaDax8KmBkUHV3U5PMDSA2aSGQ/iWCruoV4TeaCAI1nX1AW0kAH8Q9Uwkb6f8Q==}
+  '@fedify/uri-template@2.3.0':
+    resolution: {integrity: sha512-zrz545OoolziHb4Hhld8xEZuiG8Aij8I+1I12RARs1Pdz3wguzQwkmhi5A2jqYiz5W5XPzz3XDYEZUm7Ayzsyg==}
     engines: {bun: '>=1.1.0', deno: '>=2.0.0', node: '>=22.0.0'}
 
-  '@fedify/vocab-tools@2.2.1':
-    resolution: {integrity: sha512-b8Gu/clgudHjSSWEVrzm3N85xlAk23keNAxLPL6uQp+oybtG7ZvBXyUMOwFvrQLKtAmcPvRh0XXVETMN2hWv2g==}
+  '@fedify/vocab-runtime@2.3.0':
+    resolution: {integrity: sha512-FRp9HEm/lpVPJrlknHMSZJBjIgTZQlpZJjZq8lSEtgiA+hQAWGhnUNn8/jwq37BSNJ3bEH62uDFuQGxs71g+ZQ==}
     engines: {bun: '>=1.1.0', deno: '>=2.0.0', node: '>=22.0.0'}
 
-  '@fedify/vocab@2.2.1':
-    resolution: {integrity: sha512-sYVnwJLUYEiG6AuxR7Q+eYA3c+PzcZSDGxjmkFnMQ4mO1IU6G9Od85b66buGIV29g1+mgTYJLkBvNiLEOqBbaA==}
+  '@fedify/vocab-tools@2.3.0':
+    resolution: {integrity: sha512-iRy3m8HG2Ogm14VBWiIlq9y6Ten4bnDy7cXdVnU0J0/Yy+1R73lwa5pjcSUpzMf7L43iGRSD/eNwooiRDDDPfg==}
     engines: {bun: '>=1.1.0', deno: '>=2.0.0', node: '>=22.0.0'}
 
-  '@fedify/webfinger@2.2.1':
-    resolution: {integrity: sha512-gRGgjCLgfvovLstTAa7U4d170SsQQSb0pIPCyE7hMRvzdgU+uIPwbtgm5Btbe/ZognzCN2Q6ELx+tAsuQGbY5g==}
+  '@fedify/vocab@2.3.0':
+    resolution: {integrity: sha512-lAwVa2xdZ5mu8UJtbRsuZQzfRYVk8G/DgGZJZ2lgCkwghVsiAYvG7/Fb15Jwr6svLuIn2bYqMLecrZxR+LJURQ==}
+    engines: {bun: '>=1.1.0', deno: '>=2.0.0', node: '>=22.0.0'}
+
+  '@fedify/webfinger@2.3.0':
+    resolution: {integrity: sha512-kWYyHnobUNMEQZnxxm3xl+qHBvhilg+LY6hMoaNe7+4Vdfo7sYdFiBkU3uHUiUryVL+VC83Dc+wZMsarYKQn3w==}
     engines: {bun: '>=1.1.0', deno: '>=2.0.0', node: '>=22.0.0'}
 
   '@floating-ui/core@1.7.5':
@@ -1610,8 +1617,8 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@logtape/logtape@2.0.7':
-    resolution: {integrity: sha512-SUkjkEIfQ3zCadlLi8rfGfe4l/JRKNbp248bfLeowyUFs9KZME/k8y+5sugWYZet/gMYnmwCc9xa3J+kjDjSSQ==}
+  '@logtape/logtape@2.2.1':
+    resolution: {integrity: sha512-SkRptJUEAbGuf+/blXDxDa8sSq8no+lxJlfwPTMzrHIULOMsNZRaqT2qF3H9tmGOsaLYc+uF3orRCQfoH0qKzA==}
 
   '@mapbox/node-pre-gyp@2.0.3':
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
@@ -1865,6 +1872,12 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
   '@opentelemetry/sdk-trace-base@2.7.1':
     resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
@@ -4220,8 +4233,8 @@ packages:
     resolution: {integrity: sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.43.0:
-    resolution: {integrity: sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==}
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -7138,13 +7151,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  uri-template-router@1.0.0:
-    resolution: {integrity: sha512-WKcL9ZSIEhHE3f5P4Z47Tf0nWbcgV1ISb/OBuF8YKEYi0SQOyTLCzM6B/gAKFWZhRhqA+C/Ks8UXe2qU5W0FVg==}
-
-  url-template@3.1.1:
-    resolution: {integrity: sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
 
@@ -8412,7 +8418,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260507.1':
     optional: true
 
-  '@cloudflare/workers-types@4.20260507.1': {}
+  '@cloudflare/workers-types@4.20260625.1': {}
 
   '@colordx/core@5.4.3': {}
 
@@ -8771,39 +8777,42 @@ snapshots:
   '@fastify/accept-negotiator@2.0.1':
     optional: true
 
-  '@fedify/cfworkers@2.2.1(@cloudflare/workers-types@4.20260507.1)(@fedify/fedify@2.2.1)':
+  '@fedify/cfworkers@2.3.0(@cloudflare/workers-types@4.20260625.1)(@fedify/fedify@2.3.0)':
     dependencies:
-      '@cloudflare/workers-types': 4.20260507.1
-      '@fedify/fedify': 2.2.1
+      '@cloudflare/workers-types': 4.20260625.1
+      '@fedify/fedify': 2.3.0
 
-  '@fedify/fedify@2.2.1':
+  '@fedify/fedify@2.3.0':
     dependencies:
-      '@fedify/vocab': 2.2.1
-      '@fedify/vocab-runtime': 2.2.1
-      '@fedify/webfinger': 2.2.1
+      '@fedify/uri-template': 2.3.0
+      '@fedify/vocab': 2.3.0
+      '@fedify/vocab-runtime': 2.3.0
+      '@fedify/webfinger': 2.3.0
       '@js-temporal/polyfill': 0.5.1
-      '@logtape/logtape': 2.0.7
+      '@logtape/logtape': 2.2.1
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       byte-encodings: 1.0.11
-      es-toolkit: 1.43.0
+      es-toolkit: 1.46.1
       json-canon: 1.0.1
       jsonld: 9.0.0
       structured-field-values: 2.0.4
-      uri-template-router: 1.0.0
-      url-template: 3.1.1
       urlpattern-polyfill: 10.1.0
 
-  '@fedify/testing@2.2.1(@fedify/fedify@2.2.1)':
+  '@fedify/testing@2.3.0(@fedify/fedify@2.3.0)':
     dependencies:
-      '@fedify/fedify': 2.2.1
-      es-toolkit: 1.43.0
+      '@fedify/fedify': 2.3.0
+      es-toolkit: 1.46.1
 
-  '@fedify/vocab-runtime@2.2.1':
+  '@fedify/uri-template@2.3.0': {}
+
+  '@fedify/vocab-runtime@2.3.0':
     dependencies:
-      '@logtape/logtape': 2.0.7
+      '@js-temporal/polyfill': 0.5.1
+      '@logtape/logtape': 2.2.1
       '@multiformats/base-x': 4.0.1
       '@opentelemetry/api': 1.9.1
       asn1js: 3.0.10
@@ -8811,33 +8820,33 @@ snapshots:
       jsonld: 9.0.0
       pkijs: 3.4.0
 
-  '@fedify/vocab-tools@2.2.1':
+  '@fedify/vocab-tools@2.3.0':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       byte-encodings: 1.0.11
-      es-toolkit: 1.43.0
-      yaml: 2.8.4
+      es-toolkit: 1.46.1
+      yaml: 2.9.0
 
-  '@fedify/vocab@2.2.1':
+  '@fedify/vocab@2.3.0':
     dependencies:
-      '@fedify/vocab-runtime': 2.2.1
-      '@fedify/vocab-tools': 2.2.1
-      '@fedify/webfinger': 2.2.1
+      '@fedify/vocab-runtime': 2.3.0
+      '@fedify/vocab-tools': 2.3.0
+      '@fedify/webfinger': 2.3.0
       '@js-temporal/polyfill': 0.5.1
-      '@logtape/logtape': 2.0.7
+      '@logtape/logtape': 2.2.1
       '@multiformats/base-x': 4.0.1
       '@opentelemetry/api': 1.9.1
       asn1js: 3.0.10
-      es-toolkit: 1.43.0
+      es-toolkit: 1.46.1
       jsonld: 9.0.0
       pkijs: 3.4.0
 
-  '@fedify/webfinger@2.2.1':
+  '@fedify/webfinger@2.3.0':
     dependencies:
-      '@fedify/vocab-runtime': 2.2.1
-      '@logtape/logtape': 2.0.7
+      '@fedify/vocab-runtime': 2.3.0
+      '@logtape/logtape': 2.2.1
       '@opentelemetry/api': 1.9.1
-      es-toolkit: 1.43.0
+      es-toolkit: 1.46.1
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -9058,7 +9067,7 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@logtape/logtape@2.0.7': {}
+  '@logtape/logtape@2.2.1': {}
 
   '@mapbox/node-pre-gyp@2.0.3':
     dependencies:
@@ -9869,6 +9878,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -12009,7 +12024,7 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  es-toolkit@1.43.0: {}
+  es-toolkit@1.46.1: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -15891,10 +15906,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  uri-template-router@1.0.0: {}
-
-  url-template@3.1.1: {}
-
   urlpattern-polyfill@10.1.0: {}
 
   util-deprecate@1.0.2: {}
@@ -16293,7 +16304,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260507.1
       '@cloudflare/workerd-windows-64': 1.20260507.1
 
-  wrangler@4.90.0(@cloudflare/workers-types@4.20260507.1):
+  wrangler@4.90.0(@cloudflare/workers-types@4.20260625.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260507.1)
@@ -16304,7 +16315,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260507.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260507.1
+      '@cloudflare/workers-types': 4.20260625.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/server/utils/activityPubAdmin.ts
+++ b/server/utils/activityPubAdmin.ts
@@ -1,5 +1,5 @@
 import { Article, Create, EmojiReact, Follow, Image, isActor, Like, Link, Note, PUBLIC_COLLECTION, type Actor } from "@fedify/vocab"
-import { Temporal } from "@js-temporal/polyfill"
+import { Temporal as TemporalPolyfill } from "@js-temporal/polyfill"
 
 import { createFedifyContext, getCloudflareEnv } from "./fedify"
 import { ACTOR_IDENTIFIER, SITE_ORIGIN } from "./fedifyContent"
@@ -109,6 +109,10 @@ type DbChangeResult = {
 
 function getDatabase() {
   return useDatabase()
+}
+
+function nowInstant(): Temporal.Instant {
+  return TemporalPolyfill.Now.instant() as unknown as Temporal.Instant
 }
 
 function normalizeRowsChanged(value: unknown): number {
@@ -546,7 +550,7 @@ export async function replyActivityPubCommentById(
     throw new Error("Comment actor not found")
   }
 
-  const publishedAt = Temporal.Now.instant()
+  const publishedAt = nowInstant()
   const { objectId: replyId, activityId: createId } = createLocalReplyPermalinks()
   const reply = new Note({
     id: replyId,
@@ -637,7 +641,7 @@ export async function reactActivityPubCommentById(
       object: target,
       to: targetActor,
       cc: PUBLIC_COLLECTION,
-      published: Temporal.Now.instant(),
+      published: nowInstant(),
     })
     : new EmojiReact({
       id: new URL(`#react-comment-${crypto.randomUUID()}`, actorUri),
@@ -646,7 +650,7 @@ export async function reactActivityPubCommentById(
       content: reaction,
       to: targetActor,
       cc: PUBLIC_COLLECTION,
-      published: Temporal.Now.instant(),
+      published: nowInstant(),
     })
 
   await context.sendActivity(
@@ -914,7 +918,7 @@ export async function replyRemoteActivityPubObject(
   const targetObjectUri = normalizeRemoteUrl(target.objectId, "Search target object id")
   const targetActorUri = normalizeRemoteUrl(target.actorId, "Search target actor id")
   const actorUri = new URL(`/@${ACTOR_IDENTIFIER}`, SITE_ORIGIN)
-  const publishedAt = Temporal.Now.instant()
+  const publishedAt = nowInstant()
   const { objectId: replyId, activityId: createId } = createLocalReplyPermalinks()
   const replyNote = new Note({
     id: replyId,
@@ -975,7 +979,7 @@ export async function reactRemoteActivityPubObject(
       object: targetObjectUri,
       to: targetActorUri,
       cc: PUBLIC_COLLECTION,
-      published: Temporal.Now.instant(),
+      published: nowInstant(),
     })
     : new EmojiReact({
       id: new URL(`#react-remote-${crypto.randomUUID()}`, actorUri),
@@ -984,7 +988,7 @@ export async function reactRemoteActivityPubObject(
       content: reaction,
       to: targetActorUri,
       cc: PUBLIC_COLLECTION,
-      published: Temporal.Now.instant(),
+      published: nowInstant(),
     })
 
   await target.context.sendActivity(

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -7,7 +7,7 @@ import {
   Note,
   PUBLIC_COLLECTION,
 } from "@fedify/vocab"
-import { Temporal } from "@js-temporal/polyfill"
+import { Temporal as TemporalPolyfill } from "@js-temporal/polyfill"
 
 import {
   FEDIFY_BLOG_CANONICAL_HOSTNAMES,
@@ -131,7 +131,7 @@ function parseInstant(value?: string | null): Temporal.Instant | null {
     return null
   }
   try {
-    return Temporal.Instant.from(value)
+    return TemporalPolyfill.Instant.from(value) as unknown as Temporal.Instant
   } catch {
     return null
   }

--- a/server/utils/fedifyContent.ts
+++ b/server/utils/fedifyContent.ts
@@ -1,4 +1,4 @@
-import { Temporal } from "@js-temporal/polyfill"
+import { Temporal as TemporalPolyfill } from "@js-temporal/polyfill"
 import {
   Article,
   Create,
@@ -364,15 +364,16 @@ function resolveLegacyArticleUrls(entry: FedifyContentEntry, canonicalUrl: URL):
 }
 
 function normalizeDate(value?: string | Date | null): Temporal.Instant {
-  const fallback = Temporal.Instant.from(new Date().toISOString())
+  const instantFromIso = (iso: string): Temporal.Instant => TemporalPolyfill.Instant.from(iso) as unknown as Temporal.Instant
+  const fallback = instantFromIso(new Date().toISOString())
   if (!value) {
     return fallback
   }
   if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? fallback : Temporal.Instant.from(value.toISOString())
+    return Number.isNaN(value.getTime()) ? fallback : instantFromIso(value.toISOString())
   }
   const parsed = new Date(value)
-  return Number.isNaN(parsed.getTime()) ? fallback : Temporal.Instant.from(parsed.toISOString())
+  return Number.isNaN(parsed.getTime()) ? fallback : instantFromIso(parsed.toISOString())
 }
 
 export function resolveFedifyActivityId(articleUrl: URL | string): URL {

--- a/server/utils/fedifyContent.ts
+++ b/server/utils/fedifyContent.ts
@@ -363,8 +363,9 @@ function resolveLegacyArticleUrls(entry: FedifyContentEntry, canonicalUrl: URL):
   return Array.from(legacy, (url) => new URL(url))
 }
 
+const instantFromIso = (iso: string): Temporal.Instant => TemporalPolyfill.Instant.from(iso) as unknown as Temporal.Instant
+
 function normalizeDate(value?: string | Date | null): Temporal.Instant {
-  const instantFromIso = (iso: string): Temporal.Instant => TemporalPolyfill.Instant.from(iso) as unknown as Temporal.Instant
   const fallback = instantFromIso(new Date().toISOString())
   if (!value) {
     return fallback

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,7 +15,7 @@ routes = [
 crons = ["*/10 * * * *"]
 
 [build]
-command = "NODE_OPTIONS=--max-old-space-size=6144 pnpm build"
+command = "NODE_OPTIONS=--max-old-space-size=8192 pnpm build"
 
 [assets]
 directory = ".output/public"


### PR DESCRIPTION
## Summary
- Update Fedify runtime packages together to `2.3.0`: `@fedify/cfworkers`, `@fedify/fedify`, and `@fedify/vocab`.
- Update `@fedify/testing` to `2.3.0` and add `@cloudflare/workers-types@4.20260625.1` to satisfy the Cloudflare/Fedify peer dependency range.
- Increase the Cloudflare branch build heap from 6144 MB to 8192 MB through the Wrangler build command.
- Adjust Temporal polyfill usage so Fedify 2.3.0 vocab types compile cleanly.
- Move the Fedify content Temporal conversion helper to module scope after review feedback.

## Why
Dependabot can update related Fedify packages independently, which left room for version skew between `@fedify/fedify` and `@fedify/vocab`. Keeping the Fedify packages aligned avoids incompatible type/runtime combinations, and the larger build heap gives Cloudflare branch deployments enough memory for the Nuxt build.

Fedify 2.3.0's generated vocab declarations expect global `Temporal.Instant` values, while `@js-temporal/polyfill` exposes its own imported namespace types. The explicit `TemporalPolyfill` alias plus cast keeps the runtime polyfill usage intact while satisfying Fedify's generated TypeScript surface.

## Commits
- `0484459` chore: update fedify packages to 2.3.0
- `67fb49f` chore: address temporal helper review

## Validation
- `corepack pnpm install --frozen-lockfile`
- Confirmed no Fedify 2.2.x package entries remain in `package.json` or `pnpm-lock.yaml`
- `NODE_OPTIONS=--max-old-space-size=8192 corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm exec wrangler deploy .output/server/index.mjs --assets .output/public --dry-run`