### PR TITLE
Add Bluesky link-card auto-sharing for published content

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ Stored posts are exposed at `/following/`; `/feed` redirects there. Individual i
 
 Only allow follows or relay-style actors from sources you trust, because they can increase inbound traffic and affect what appears in the following feed.
 
+## Bluesky auto-sharing
+
+New `blog` and `app` entries published by `ap:publishNewContent` can also create one link-card post on a configured Bluesky account. The Bluesky post contains a short plain-text summary and an external card that links to the browser-facing canonical URL. A usable cover image is uploaded as the card thumbnail; missing, invalid, failed, or oversized images fall back to the same card without a thumbnail.
+
+This is a one-way, create-only notification. Existing content is not backfilled, and later article edits/deletes, reposts, replies/comments, likes/reactions, and follows do not update Bluesky.
+
+Create a dedicated Bluesky app password, then store the handle and app password as Cloudflare secrets without committing either value:
+
+```bash
+pnpm exec wrangler secret put BSKY_USER
+pnpm exec wrangler secret put BSKY_PASSWORD
+```
+
+When both secrets are absent, Bluesky sharing is disabled and ActivityPub publication continues unchanged. When only one secret is present, new shares remain pending and the task reports a redacted configuration error. Authentication, upload, rate-limit, and create failures also leave a durable pending row with bounded exponential backoff; they do not roll back or block ActivityPub publication.
+
+Operators can inspect delivery state without exposing credentials or session tokens:
+
+```bash
+pnpm exec wrangler d1 execute changkyun-kim --remote \
+  --command "SELECT source_url, status, attempt_count, next_attempt_at, last_error, at_uri FROM bluesky_shares ORDER BY created_at DESC LIMIT 20"
+```
+
+`pending` rows will be retried by the scheduled publication task. `conflict` means the persisted AT Protocol record key resolves to different content and requires operator investigation. Successful rows retain their AT URI and CID for deduplication and auditing.
+
 ## Local ActivityPub Admin CLI
 
 원격 로그인 없이 ActivityPub 반응을 관리하려면 로컬 워크스페이스 패키지인 `packages/admin`을 사용합니다.

--- a/migrations/0006_bluesky_shares.sql
+++ b/migrations/0006_bluesky_shares.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS bluesky_shares (
+  source_activity_id TEXT PRIMARY KEY,
+  source_url TEXT NOT NULL,
+  record_key TEXT NOT NULL,
+  record_json TEXT NOT NULL,
+  cover_image_url TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  at_uri TEXT,
+  cid TEXT,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at TEXT,
+  last_error TEXT,
+  posted_at TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK (status IN ('pending', 'posted', 'conflict'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ix_bluesky_shares_record_key ON bluesky_shares(record_key);
+CREATE INDEX IF NOT EXISTS ix_bluesky_shares_pending ON bluesky_shares(status, next_attempt_at);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "generate": "GENERATE=1 nuxi generate",
     "prepare": "nuxi prepare",
     "preview": "nuxi preview",
+    "test": "node --experimental-strip-types --test tests/*.test.ts",
     "typecheck": "nuxi typecheck",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
@@ -51,6 +52,7 @@
     "sharp": "^0.34.5",
     "tailwindcss": "^4.2.4",
     "typescript": "5.9.3",
+    "vue-tsc": "3.3.8",
     "wrangler": "^4.90.0"
   },
   "resolutions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 1.0.0
       nuxt:
         specifier: ^4.4.7
-        version: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 4.20260625.1
@@ -100,6 +100,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vue-tsc:
+        specifier: 3.3.8
+        version: 3.3.8(typescript@5.9.3)
       wrangler:
         specifier: ^4.90.0
         version: 4.90.0(@cloudflare/workers-types@4.20260625.1)
@@ -3309,6 +3312,9 @@ packages:
   '@vue/language-core@3.2.8':
     resolution: {integrity: sha512-9OiSPQFiAAWNVnXb0d2dcTmcKnFQamhuNES6ayyISrb/mwPWVgoGdAqSfCWqKhQpa3D5gDTcYD+w7ObiheZ81g==}
 
+  '@vue/language-core@3.3.8':
+    resolution: {integrity: sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==}
+
   '@vue/reactivity@3.5.38':
     resolution: {integrity: sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==}
 
@@ -3436,6 +3442,9 @@ packages:
 
   alien-signals@3.1.2:
     resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -7341,6 +7350,12 @@ packages:
       vite:
         optional: true
 
+  vue-tsc@3.3.8:
+    resolution: {integrity: sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
   vue@3.5.38:
     resolution: {integrity: sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==}
     peerDependencies:
@@ -9539,7 +9554,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.7(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(better-sqlite3@12.9.0)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.133.0)(srvx@0.11.16)(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.4.7(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(better-sqlite3@12.9.0)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.133.0)(srvx@0.11.16)(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
@@ -9557,7 +9572,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(better-sqlite3@12.9.0)(oxc-parser@0.133.0)(srvx@0.11.16)
-      nuxt: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.7
       ohash: 2.0.11
       pathe: 2.0.3
@@ -9749,7 +9764,7 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@types/node@25.6.2)(eslint@10.3.0(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.4.7(hxxpnopxm3dse2pk6zssyecg5m)':
     dependencies:
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.0)
@@ -9767,7 +9782,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.7
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -9778,7 +9793,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-node: 5.3.0(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vite-plugin-checker: 0.14.3(eslint@10.3.0(jiti@2.7.0))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite-plugin-checker: 0.14.3(eslint@10.3.0(jiti@2.7.0))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))
       vue: 3.5.38(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -11120,6 +11135,16 @@ snapshots:
       path-browserify: 1.0.1
       picomatch: 4.0.4
 
+  '@vue/language-core@3.3.8':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.38
+      '@vue/shared': 3.5.38
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.4
+
   '@vue/reactivity@3.5.38':
     dependencies:
       '@vue/shared': 3.5.38
@@ -11228,6 +11253,8 @@ snapshots:
       require-from-string: 2.0.2
 
   alien-signals@3.1.2: {}
+
+  alien-signals@3.2.1: {}
 
   ansi-regex@5.0.1: {}
 
@@ -13987,16 +14014,16 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@5.9.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.7)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.7(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(better-sqlite3@12.9.0)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.133.0)(srvx@0.11.16)(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.4.7(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(better-sqlite3@12.9.0)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.133.0)(srvx@0.11.16)(typescript@5.9.3)
       '@nuxt/schema': 4.4.7
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.7(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@types/node@25.6.2)(eslint@10.3.0(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.0))(@types/node@25.6.2)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.4.7(hxxpnopxm3dse2pk6zssyecg5m)
       '@unhead/vue': 2.1.15(vue@3.5.38(typescript@5.9.3))
       '@vue/shared': 3.5.38
       chokidar: 5.0.0
@@ -15963,7 +15990,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.14.3(eslint@10.3.0(jiti@2.7.0))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vite-plugin-checker@0.14.3(eslint@10.3.0(jiti@2.7.0))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -15977,6 +16004,7 @@ snapshots:
       eslint: 10.3.0(jiti@2.7.0)
       optionator: 0.9.4
       typescript: 5.9.3
+      vue-tsc: 3.3.8(typescript@5.9.3)
 
   vite-plugin-inspect@11.4.1(@nuxt/kit@4.4.7(magicast@0.5.3))(vite@7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
@@ -16088,6 +16116,12 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.38
       vite: 7.3.5(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  vue-tsc@3.3.8(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.8
+      typescript: 5.9.3
 
   vue@3.5.38(typescript@5.9.3):
     dependencies:

--- a/server/plugins/fedify-cloudflare.ts
+++ b/server/plugins/fedify-cloudflare.ts
@@ -13,14 +13,19 @@ export default defineNitroPlugin((nitroApp) => {
     }
   })
 
-  nitroApp.hooks.hook("cloudflare:scheduled", async () => {
+  nitroApp.hooks.hook("cloudflare:scheduled", async ({ env }) => {
+    const taskOptions = {
+      context: {
+        cloudflare: { env },
+      },
+    }
     try {
-      await runTask("ap:publishNewContent")
+      await runTask("ap:publishNewContent", taskOptions)
     } catch (error) {
       console.error("Failed publishing ActivityPub content on schedule", error)
     }
     try {
-      await runTask("ap:crawlFeed")
+      await runTask("ap:crawlFeed", taskOptions)
     } catch (error) {
       console.error("Failed crawling ActivityPub feed on schedule", error)
     }

--- a/server/routes/__activitypub/publish.post.ts
+++ b/server/routes/__activitypub/publish.post.ts
@@ -11,5 +11,9 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  return await runTask("ap:publishNewContent")
+  return await runTask("ap:publishNewContent", {
+    context: {
+      cloudflare: { env },
+    },
+  })
 })

--- a/server/tasks/ap/publishNewContent.ts
+++ b/server/tasks/ap/publishNewContent.ts
@@ -10,6 +10,15 @@ import {
 } from "../../utils/fedifyContent"
 import { createFedifyContext, getCloudflareEnv } from "../../utils/fedify"
 import { ensureActivityPubSchema } from "../../utils/activityPubSchema"
+import {
+  resolveBlueskyConfig,
+  shouldQueueBlueskyShare,
+  type BlueskyConfig,
+} from "../../utils/bluesky"
+import {
+  processPendingBlueskyShares,
+  queueBlueskyShare,
+} from "../../utils/blueskyShare"
 
 const COLLECTIONS = ["blog", "app"] as const
 
@@ -173,7 +182,11 @@ async function persistOutboxActivity(activity: Create): Promise<void> {
   )`
 }
 
-async function publishCollection(collection: typeof COLLECTIONS[number], env: ReturnType<typeof getCloudflareEnv>) {
+async function publishCollection(
+  collection: typeof COLLECTIONS[number],
+  env: ReturnType<typeof getCloudflareEnv>,
+  blueskyConfig: BlueskyConfig,
+) {
   const initialState = await getDeliveryState(collection)
   let initialLastPublishedTime: number | null = null
   if (initialState?.lastPublishedAt) {
@@ -194,6 +207,7 @@ async function publishCollection(collection: typeof COLLECTIONS[number], env: Re
   let lastDeliveredPath = initialState?.lastDocumentPath ?? null
   let lastDeliveredActivityId = initialState?.lastActivityId ?? null
   let published = 0
+  let blueskyQueued = 0
 
   for (const entry of entries) {
     const activity = await buildCreateFromEntry(entry)
@@ -224,19 +238,24 @@ async function publishCollection(collection: typeof COLLECTIONS[number], env: Re
       }
     }
 
-    if (await hasExistingOutboxActivity(activity, entry)) {
-      continue
+    const alreadyPublished = await hasExistingOutboxActivity(activity, entry)
+    if (!alreadyPublished) {
+      if (shouldQueueBlueskyShare(blueskyConfig.status, alreadyPublished)
+        && await queueBlueskyShare(activity.id.href, entry)) {
+        blueskyQueued += 1
+      }
+
+      await persistOutboxActivity(activity)
+
+      const ctx = await createFedifyContext(env)
+      await ctx.sendActivity(
+        { identifier: ACTOR_IDENTIFIER },
+        "followers",
+        activity,
+        { preferSharedInbox: true },
+      )
+      published += 1
     }
-
-    await persistOutboxActivity(activity)
-
-    const ctx = await createFedifyContext(env)
-    await ctx.sendActivity(
-      { identifier: ACTOR_IDENTIFIER },
-      "followers",
-      activity,
-      { preferSharedInbox: true },
-    )
 
     await updateDeliveryState({
       collection,
@@ -250,10 +269,9 @@ async function publishCollection(collection: typeof COLLECTIONS[number], env: Re
     lastDeliveredTime = publishedTime
     lastDeliveredPath = documentPath ?? lastDeliveredPath
     lastDeliveredActivityId = activity.id.href
-    published += 1
   }
 
-  return published
+  return { published, blueskyQueued }
 }
 
 export default defineTask({
@@ -264,10 +282,22 @@ export default defineTask({
   async run(event) {
     await ensureActivityPubSchema()
     const env = getCloudflareEnv(event)
+    const blueskyConfig = resolveBlueskyConfig(env)
     let published = 0
+    let blueskyQueued = 0
     for (const collection of COLLECTIONS) {
-      published += await publishCollection(collection, env)
+      const collectionResult = await publishCollection(collection, env, blueskyConfig)
+      published += collectionResult.published
+      blueskyQueued += collectionResult.blueskyQueued
     }
-    return { result: true, published }
+    const bluesky = await processPendingBlueskyShares(blueskyConfig)
+    return {
+      result: true,
+      published,
+      bluesky: {
+        ...bluesky,
+        queued: blueskyQueued,
+      },
+    }
   },
 })

--- a/server/utils/activityPubAdmin.ts
+++ b/server/utils/activityPubAdmin.ts
@@ -12,6 +12,8 @@ import {
   persistLocalReplyComment,
 } from "./fedifyComments"
 
+type TemporalInstant = ReturnType<typeof TemporalPolyfill.Now.instant>
+
 export type AdminFollowItem = {
   id: number
   actorId: string
@@ -111,8 +113,8 @@ function getDatabase() {
   return useDatabase()
 }
 
-function nowInstant(): Temporal.Instant {
-  return TemporalPolyfill.Now.instant() as unknown as Temporal.Instant
+function nowInstant(): TemporalInstant {
+  return TemporalPolyfill.Now.instant()
 }
 
 function normalizeRowsChanged(value: unknown): number {

--- a/server/utils/activityPubSchema.ts
+++ b/server/utils/activityPubSchema.ts
@@ -87,6 +87,26 @@ async function runActivityPubSchema() {
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
   );`
 
+  await db.sql`CREATE TABLE IF NOT EXISTS bluesky_shares (
+    source_activity_id TEXT PRIMARY KEY,
+    source_url TEXT NOT NULL,
+    record_key TEXT NOT NULL,
+    record_json TEXT NOT NULL,
+    cover_image_url TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    at_uri TEXT,
+    cid TEXT,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at TEXT,
+    last_error TEXT,
+    posted_at TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (status IN ('pending', 'posted', 'conflict'))
+  );`
+  await db.sql`CREATE UNIQUE INDEX IF NOT EXISTS ix_bluesky_shares_record_key ON bluesky_shares(record_key);`
+  await db.sql`CREATE INDEX IF NOT EXISTS ix_bluesky_shares_pending ON bluesky_shares(status, next_attempt_at);`
+
   await db.sql`CREATE TABLE IF NOT EXISTS activitypub_comments (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     object_id TEXT NOT NULL,

--- a/server/utils/bluesky.ts
+++ b/server/utils/bluesky.ts
@@ -1,0 +1,643 @@
+const BLUESKY_ENTRYWAY = "https://bsky.social"
+const BLUESKY_POST_COLLECTION = "app.bsky.feed.post"
+const BLUESKY_POST_MAX_GRAPHEMES = 300
+const BLUESKY_POST_MAX_BYTES = 3000
+const BLUESKY_CARD_IMAGE_MAX_BYTES = 1_000_000
+const BLUESKY_RETRY_BASE_MS = 10 * 60 * 1000
+const BLUESKY_RETRY_MAX_MS = 6 * 60 * 60 * 1000
+const S32_CHARACTERS = "234567abcdefghijklmnopqrstuvwxyz"
+
+let lastTidTimestamp = 0
+let tidClockId: number | null = null
+
+export type BlueskyEnvironment = {
+  BSKY_USER?: string
+  BSKY_PASSWORD?: string
+}
+
+export type BlueskyConfig =
+  | { status: "disabled" }
+  | { status: "incomplete" }
+  | { status: "enabled"; user: string; password: string }
+
+export type BlueskyBlob = {
+  $type: "blob"
+  ref: {
+    $link: string
+  }
+  mimeType: string
+  size: number
+}
+
+export type BlueskyPostRecord = {
+  $type: "app.bsky.feed.post"
+  text: string
+  createdAt: string
+  embed: {
+    $type: "app.bsky.embed.external"
+    external: {
+      uri: string
+      title: string
+      description: string
+      thumb?: BlueskyBlob
+    }
+  }
+}
+
+export type BlueskyShareSource = {
+  title?: string | null
+  stem?: string | null
+  description?: string | null
+  body?: unknown
+  coverImage?: string | null
+}
+
+export type BlueskyShareDraft = {
+  recordKey: string
+  record: BlueskyPostRecord
+  coverImageUrl: string | null
+}
+
+export type BlueskySession = {
+  accessJwt: string
+  did: string
+  pdsUrl: string
+}
+
+export type BlueskyRecordResult = {
+  uri: string
+  cid: string | null
+}
+
+export type BlueskyThumbnailResult = {
+  record: BlueskyPostRecord
+  outcome: "attached" | "skipped"
+}
+
+export class BlueskyXrpcError extends Error {
+  status: number
+  errorCode: string | null
+
+  constructor(method: string, status: number, errorCode: string | null = null) {
+    const suffix = errorCode ? `: ${errorCode}` : ""
+    super(`Bluesky XRPC ${method} failed with HTTP ${status}${suffix}.`)
+    this.name = "BlueskyXrpcError"
+    this.status = status
+    this.errorCode = errorCode
+  }
+}
+
+export class BlueskyRecordConflictError extends Error {
+  constructor() {
+    super("The persisted Bluesky record key already contains a different record.")
+    this.name = "BlueskyRecordConflictError"
+  }
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value ? value : null
+}
+
+function safeErrorCode(value: unknown): string | null {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_.-]{1,80}$/.test(value)) {
+    return null
+  }
+  return value
+}
+
+async function parseResponseJson(response: Response): Promise<Record<string, any>> {
+  try {
+    const value = await response.json()
+    return value && typeof value === "object" ? value as Record<string, any> : {}
+  } catch {
+    return {}
+  }
+}
+
+function xrpcUrl(baseUrl: string, method: string, query?: URLSearchParams): string {
+  const base = baseUrl.replace(/\/+$/, "")
+  const suffix = query?.size ? `?${query.toString()}` : ""
+  return `${base}/xrpc/${method}${suffix}`
+}
+
+async function xrpcJson(
+  fetcher: typeof fetch,
+  baseUrl: string,
+  method: string,
+  options: {
+    accessJwt?: string
+    body?: Record<string, unknown>
+    query?: URLSearchParams
+  } = {},
+): Promise<Record<string, any>> {
+  const headers = new Headers()
+  headers.set("accept", "application/json")
+  if (options.body) {
+    headers.set("content-type", "application/json")
+  }
+  if (options.accessJwt) {
+    headers.set("authorization", `Bearer ${options.accessJwt}`)
+  }
+
+  let response: Response
+  try {
+    response = await fetcher(xrpcUrl(baseUrl, method, options.query), {
+      method: options.body ? "POST" : "GET",
+      headers,
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    })
+  } catch {
+    throw new Error(`Bluesky XRPC ${method} request failed before receiving a response.`)
+  }
+
+  const data = await parseResponseJson(response)
+  if (!response.ok) {
+    throw new BlueskyXrpcError(method, response.status, safeErrorCode(data.error))
+  }
+  return data
+}
+
+function resolvePdsUrl(didDoc: unknown): string {
+  if (!didDoc || typeof didDoc !== "object") {
+    return BLUESKY_ENTRYWAY
+  }
+  const services = (didDoc as { service?: unknown }).service
+  if (!Array.isArray(services)) {
+    return BLUESKY_ENTRYWAY
+  }
+
+  for (const service of services) {
+    if (!service || typeof service !== "object") {
+      continue
+    }
+    const value = service as {
+      id?: unknown
+      type?: unknown
+      serviceEndpoint?: unknown
+    }
+    const isPds = (typeof value.id === "string" && value.id.endsWith("#atproto_pds"))
+      || value.type === "AtprotoPersonalDataServer"
+    if (!isPds || typeof value.serviceEndpoint !== "string") {
+      continue
+    }
+    try {
+      const endpoint = new URL(value.serviceEndpoint)
+      if (endpoint.protocol === "https:" && !endpoint.username && !endpoint.password) {
+        return endpoint.href.replace(/\/+$/, "")
+      }
+    } catch {
+      continue
+    }
+  }
+  return BLUESKY_ENTRYWAY
+}
+
+function s32encode(value: number): string {
+  let remaining = value
+  let encoded = ""
+  while (remaining) {
+    const index = remaining % 32
+    remaining = Math.floor(remaining / 32)
+    encoded = S32_CHARACTERS.charAt(index) + encoded
+  }
+  return encoded
+}
+
+export function createBlueskyRecordKey(now = Date.now()): string {
+  const timestamp = Math.max(now * 1000, lastTidTimestamp + 1)
+  lastTidTimestamp = timestamp
+
+  if (tidClockId === null) {
+    const random = new Uint16Array(1)
+    crypto.getRandomValues(random)
+    tidClockId = (random[0] ?? 0) % 1024
+  }
+
+  return `${s32encode(timestamp)}${s32encode(tidClockId).padStart(2, "2")}`
+}
+
+export function resolveBlueskyConfig(env?: BlueskyEnvironment | null): BlueskyConfig {
+  const user = env?.BSKY_USER?.trim() ?? ""
+  const password = env?.BSKY_PASSWORD?.trim() ?? ""
+  if (!user && !password) {
+    return { status: "disabled" }
+  }
+  if (!user || !password) {
+    return { status: "incomplete" }
+  }
+  return { status: "enabled", user, password }
+}
+
+export function nextBlueskyAttemptAt(attemptCount: number, now = new Date()): string {
+  const exponent = Math.max(0, Math.min(10, attemptCount - 1))
+  const delay = Math.min(BLUESKY_RETRY_MAX_MS, BLUESKY_RETRY_BASE_MS * (2 ** exponent))
+  return new Date(now.getTime() + delay).toISOString()
+}
+
+export function shouldQueueBlueskyShare(
+  configuration: BlueskyConfig["status"],
+  alreadyPublished: boolean,
+): boolean {
+  return configuration !== "disabled"
+    && !alreadyPublished
+}
+
+function decodeHtmlEntities(value: string): string {
+  const named: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: "\"",
+  }
+  return value.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, entity: string) => {
+    if (entity.startsWith("#")) {
+      const isHex = entity[1]?.toLowerCase() === "x"
+      const parsed = Number.parseInt(entity.slice(isHex ? 2 : 1), isHex ? 16 : 10)
+      if (Number.isFinite(parsed) && parsed > 0 && parsed <= 0x10ffff) {
+        return String.fromCodePoint(parsed)
+      }
+      return match
+    }
+    return named[entity.toLowerCase()] ?? match
+  })
+}
+
+function collectContentText(value: unknown, seen = new Set<unknown>()): string {
+  if (typeof value === "string") {
+    return value
+  }
+  if (!value || typeof value !== "object" || seen.has(value)) {
+    return ""
+  }
+  seen.add(value)
+  if (Array.isArray(value)) {
+    return value.map((item) => collectContentText(item, seen)).filter(Boolean).join(" ")
+  }
+
+  const record = value as Record<string, unknown>
+  const direct = [record.value, record.text, record.code]
+    .filter((item): item is string => typeof item === "string")
+    .join(" ")
+  const nested = [record.children, record.content, record.body]
+    .map((item) => collectContentText(item, seen))
+    .filter(Boolean)
+    .join(" ")
+  return [direct, nested].filter(Boolean).join(" ")
+}
+
+export function normalizeBlueskyText(value: unknown): string {
+  const text = collectContentText(value)
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/```[a-z0-9_-]*\s*/gi, " ")
+    .replace(/[`*_~]/g, "")
+    .replace(/^\s{0,3}(?:#{1,6}|>|[-+])\s+/gm, "")
+    .replace(/^\s{0,3}\d+[.)]\s+/gm, "")
+  return decodeHtmlEntities(text).replace(/\s+/g, " ").trim()
+}
+
+export function truncateBlueskyText(
+  value: string,
+  maxGraphemes = BLUESKY_POST_MAX_GRAPHEMES,
+  maxBytes = BLUESKY_POST_MAX_BYTES,
+): string {
+  const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" })
+  const encoder = new TextEncoder()
+  const segments: string[] = []
+  let bytes = 0
+
+  for (const item of segmenter.segment(value)) {
+    if (segments.length >= maxGraphemes) {
+      break
+    }
+    const segmentBytes = encoder.encode(item.segment).byteLength
+    if (bytes + segmentBytes > maxBytes) {
+      break
+    }
+    segments.push(item.segment)
+    bytes += segmentBytes
+  }
+  return segments.join("").trim()
+}
+
+function resolveCoverImageUrl(value: string | null | undefined, siteOrigin: string): string | null {
+  if (!value) {
+    return null
+  }
+  try {
+    const url = new URL(value, siteOrigin)
+    return url.protocol === "http:" || url.protocol === "https:" ? url.href : null
+  } catch {
+    return null
+  }
+}
+
+export function buildBlueskyShareDraft(
+  source: BlueskyShareSource,
+  publicUrl: URL,
+  options: {
+    now?: Date
+    siteOrigin?: string
+  } = {},
+): BlueskyShareDraft {
+  const now = options.now ?? new Date()
+  const title = truncateBlueskyText(
+    normalizeBlueskyText(source.title)
+    || normalizeBlueskyText(source.stem)
+    || publicUrl.href,
+  )
+  const summary = truncateBlueskyText(
+    normalizeBlueskyText(source.description)
+    || normalizeBlueskyText(source.body)
+    || title,
+  )
+
+  return {
+    recordKey: createBlueskyRecordKey(now.getTime()),
+    record: {
+      $type: BLUESKY_POST_COLLECTION,
+      text: summary,
+      createdAt: now.toISOString(),
+      embed: {
+        $type: "app.bsky.embed.external",
+        external: {
+          uri: publicUrl.href,
+          title,
+          description: summary,
+        },
+      },
+    },
+    coverImageUrl: resolveCoverImageUrl(
+      source.coverImage,
+      options.siteOrigin ?? publicUrl.origin,
+    ),
+  }
+}
+
+export async function createBlueskySession(
+  config: Extract<BlueskyConfig, { status: "enabled" }>,
+  fetcher: typeof fetch = fetch,
+): Promise<BlueskySession> {
+  const data = await xrpcJson(fetcher, BLUESKY_ENTRYWAY, "com.atproto.server.createSession", {
+    body: {
+      identifier: config.user,
+      password: config.password,
+    },
+  })
+  const accessJwt = stringValue(data.accessJwt)
+  const did = stringValue(data.did)
+  if (!accessJwt || !did) {
+    throw new Error("Bluesky createSession returned an incomplete response.")
+  }
+  return {
+    accessJwt,
+    did,
+    pdsUrl: resolvePdsUrl(data.didDoc),
+  }
+}
+
+async function uploadBlueskyBlob(
+  session: BlueskySession,
+  bytes: Uint8Array,
+  mimeType: string,
+  fetcher: typeof fetch,
+): Promise<BlueskyBlob> {
+  const headers = new Headers({
+    accept: "application/json",
+    authorization: `Bearer ${session.accessJwt}`,
+    "content-type": mimeType,
+  })
+  const uploadBody = new Uint8Array(bytes.byteLength)
+  uploadBody.set(bytes)
+  let response: Response
+  try {
+    response = await fetcher(xrpcUrl(session.pdsUrl, "com.atproto.repo.uploadBlob"), {
+      method: "POST",
+      headers,
+      body: uploadBody.buffer,
+    })
+  } catch {
+    throw new Error("Bluesky blob upload failed before receiving a response.")
+  }
+  const data = await parseResponseJson(response)
+  if (!response.ok) {
+    throw new BlueskyXrpcError(
+      "com.atproto.repo.uploadBlob",
+      response.status,
+      safeErrorCode(data.error),
+    )
+  }
+  const blob = data.blob
+  if (
+    !blob
+    || typeof blob !== "object"
+    || blob.$type !== "blob"
+    || typeof blob.mimeType !== "string"
+    || typeof blob.size !== "number"
+    || !blob.ref
+    || typeof blob.ref.$link !== "string"
+  ) {
+    throw new Error("Bluesky blob upload returned an incomplete response.")
+  }
+  return blob as BlueskyBlob
+}
+
+async function readResponseBytes(response: Response, limit: number): Promise<Uint8Array | null> {
+  const contentLength = Number(response.headers.get("content-length"))
+  if (Number.isFinite(contentLength) && contentLength > limit) {
+    return null
+  }
+  if (!response.body) {
+    const bytes = new Uint8Array(await response.arrayBuffer())
+    return bytes.byteLength <= limit ? bytes : null
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      break
+    }
+    total += value.byteLength
+    if (total > limit) {
+      await reader.cancel()
+      return null
+    }
+    chunks.push(value)
+  }
+  const bytes = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
+export async function attachBlueskyCardThumbnail(
+  session: BlueskySession,
+  record: BlueskyPostRecord,
+  coverImageUrl: string | null,
+  fetcher: typeof fetch = fetch,
+): Promise<BlueskyThumbnailResult> {
+  if (!coverImageUrl || record.embed.external.thumb) {
+    return { record, outcome: "skipped" }
+  }
+
+  try {
+    const response = await fetcher(coverImageUrl, {
+      headers: {
+        accept: "image/*",
+      },
+    })
+    const mimeType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase() ?? ""
+    if (!response.ok || !mimeType.startsWith("image/")) {
+      return { record, outcome: "skipped" }
+    }
+    const bytes = await readResponseBytes(response, BLUESKY_CARD_IMAGE_MAX_BYTES)
+    if (!bytes) {
+      return { record, outcome: "skipped" }
+    }
+    const thumb = await uploadBlueskyBlob(session, bytes, mimeType, fetcher)
+    return {
+      outcome: "attached",
+      record: {
+        ...record,
+        embed: {
+          ...record.embed,
+          external: {
+            ...record.embed.external,
+            thumb,
+          },
+        },
+      },
+    }
+  } catch {
+    return { record, outcome: "skipped" }
+  }
+}
+
+function canonicalizeJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalizeJson).join(",")}]`
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonicalizeJson(record[key])}`).join(",")}}`
+  }
+  return JSON.stringify(value)
+}
+
+async function getBlueskyRecord(
+  session: BlueskySession,
+  recordKey: string,
+  fetcher: typeof fetch,
+): Promise<{ uri: string; cid: string | null; value: unknown } | null> {
+  const query = new URLSearchParams({
+    repo: session.did,
+    collection: BLUESKY_POST_COLLECTION,
+    rkey: recordKey,
+  })
+  try {
+    const data = await xrpcJson(fetcher, session.pdsUrl, "com.atproto.repo.getRecord", {
+      accessJwt: session.accessJwt,
+      query,
+    })
+    const uri = stringValue(data.uri)
+    if (!uri || !("value" in data)) {
+      throw new Error("Bluesky getRecord returned an incomplete response.")
+    }
+    return {
+      uri,
+      cid: stringValue(data.cid),
+      value: data.value,
+    }
+  } catch (error) {
+    if (
+      error instanceof BlueskyXrpcError
+      && (error.errorCode === "RecordNotFound" || error.status === 404)
+    ) {
+      return null
+    }
+    throw error
+  }
+}
+
+function reconcileRecord(
+  existing: { uri: string; cid: string | null; value: unknown } | null,
+  record: BlueskyPostRecord,
+): BlueskyRecordResult | null {
+  if (!existing) {
+    return null
+  }
+  if (canonicalizeJson(existing.value) !== canonicalizeJson(record)) {
+    throw new BlueskyRecordConflictError()
+  }
+  return {
+    uri: existing.uri,
+    cid: existing.cid,
+  }
+}
+
+export async function createOrReconcileBlueskyPost(
+  session: BlueskySession,
+  recordKey: string,
+  record: BlueskyPostRecord,
+  fetcher: typeof fetch = fetch,
+): Promise<BlueskyRecordResult> {
+  const existing = reconcileRecord(
+    await getBlueskyRecord(session, recordKey, fetcher),
+    record,
+  )
+  if (existing) {
+    return existing
+  }
+
+  try {
+    const data = await xrpcJson(fetcher, session.pdsUrl, "com.atproto.repo.createRecord", {
+      accessJwt: session.accessJwt,
+      body: {
+        repo: session.did,
+        collection: BLUESKY_POST_COLLECTION,
+        rkey: recordKey,
+        record,
+      },
+    })
+    const uri = stringValue(data.uri)
+    const cid = stringValue(data.cid)
+    if (!uri || !cid) {
+      throw new Error("Bluesky createRecord returned an incomplete response.")
+    }
+    return { uri, cid }
+  } catch (createError) {
+    try {
+      const reconciled = reconcileRecord(
+        await getBlueskyRecord(session, recordKey, fetcher),
+        record,
+      )
+      if (reconciled) {
+        return reconciled
+      }
+    } catch (reconcileError) {
+      if (reconcileError instanceof BlueskyRecordConflictError) {
+        throw reconcileError
+      }
+    }
+    throw createError
+  }
+}
+
+export function sanitizeBlueskyError(error: unknown): string {
+  if (error instanceof BlueskyRecordConflictError || error instanceof BlueskyXrpcError) {
+    return error.message
+  }
+  if (error instanceof Error && error.message.startsWith("Bluesky ")) {
+    return error.message
+  }
+  return "Bluesky sharing failed."
+}

--- a/server/utils/blueskyShare.ts
+++ b/server/utils/blueskyShare.ts
@@ -1,0 +1,326 @@
+import {
+  attachBlueskyCardThumbnail,
+  BlueskyRecordConflictError,
+  buildBlueskyShareDraft,
+  createBlueskySession,
+  createOrReconcileBlueskyPost,
+  nextBlueskyAttemptAt,
+  sanitizeBlueskyError,
+  type BlueskyConfig,
+  type BlueskyPostRecord,
+} from "./bluesky"
+import {
+  resolvePublicArticleUrl,
+  SITE_ORIGIN,
+  type FedifyContentEntry,
+} from "./fedifyContent"
+
+const BLUESKY_SHARE_BATCH_SIZE = 20
+
+type BlueskyShareRow = {
+  sourceActivityId: string
+  recordKey: string
+  recordJson: string
+  coverImageUrl: string | null
+  attemptCount: number
+}
+
+export type BlueskyShareRunResult = {
+  configuration: BlueskyConfig["status"]
+  attempted: number
+  shared: number
+  pending: number
+  failed: number
+  conflicts: number
+  thumbnailFallbacks: number
+}
+
+function numberValue(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function changesValue(result: unknown): number {
+  return numberValue((result as { changes?: unknown } | null)?.changes)
+}
+
+function parseBlueskyPostRecord(value: string): BlueskyPostRecord {
+  const record = JSON.parse(value) as Partial<BlueskyPostRecord>
+  if (
+    record.$type !== "app.bsky.feed.post"
+    || typeof record.text !== "string"
+    || typeof record.createdAt !== "string"
+    || record.embed?.$type !== "app.bsky.embed.external"
+    || typeof record.embed.external?.uri !== "string"
+    || typeof record.embed.external?.title !== "string"
+    || typeof record.embed.external?.description !== "string"
+  ) {
+    throw new Error("Persisted Bluesky post payload is invalid.")
+  }
+  return record as BlueskyPostRecord
+}
+
+function toShareRow(row: Record<string, any>): BlueskyShareRow {
+  return {
+    sourceActivityId: String(row.source_activity_id ?? ""),
+    recordKey: String(row.record_key ?? ""),
+    recordJson: String(row.record_json ?? ""),
+    coverImageUrl: typeof row.cover_image_url === "string" ? row.cover_image_url : null,
+    attemptCount: numberValue(row.attempt_count),
+  }
+}
+
+async function pendingShareCount(): Promise<number> {
+  const db = useDatabase()
+  const { rows } = await db.sql`
+    SELECT COUNT(*) AS count
+    FROM bluesky_shares
+    WHERE status = 'pending'
+  `
+  return numberValue((rows?.[0] as Record<string, unknown> | undefined)?.count)
+}
+
+async function listDueShares(now: Date): Promise<BlueskyShareRow[]> {
+  const db = useDatabase()
+  const { rows } = await db.sql`
+    SELECT
+      source_activity_id,
+      record_key,
+      record_json,
+      cover_image_url,
+      attempt_count
+    FROM bluesky_shares
+    WHERE status = 'pending'
+      AND datetime(next_attempt_at) <= datetime(${now.toISOString()})
+    ORDER BY datetime(next_attempt_at) ASC, created_at ASC
+    LIMIT ${BLUESKY_SHARE_BATCH_SIZE}
+  `
+  return ((rows ?? []) as Record<string, any>[]).map(toShareRow)
+}
+
+async function markShareForRetry(
+  row: BlueskyShareRow,
+  error: unknown,
+  now: Date,
+): Promise<void> {
+  const db = useDatabase()
+  const attemptCount = row.attemptCount + 1
+  const nextAttemptAt = nextBlueskyAttemptAt(attemptCount, now)
+  const lastError = sanitizeBlueskyError(error).slice(0, 240)
+  await db.sql`
+    UPDATE bluesky_shares
+    SET status = 'pending',
+        attempt_count = ${attemptCount},
+        next_attempt_at = ${nextAttemptAt},
+        last_error = ${lastError},
+        updated_at = CURRENT_TIMESTAMP
+    WHERE source_activity_id = ${row.sourceActivityId}
+  `
+}
+
+async function markShareConflict(row: BlueskyShareRow, error: unknown): Promise<void> {
+  const db = useDatabase()
+  const lastError = sanitizeBlueskyError(error).slice(0, 240)
+  await db.sql`
+    UPDATE bluesky_shares
+    SET status = 'conflict',
+        attempt_count = ${row.attemptCount + 1},
+        next_attempt_at = NULL,
+        last_error = ${lastError},
+        updated_at = CURRENT_TIMESTAMP
+    WHERE source_activity_id = ${row.sourceActivityId}
+  `
+}
+
+async function persistPreparedRecord(
+  row: BlueskyShareRow,
+  record: BlueskyPostRecord,
+): Promise<void> {
+  const db = useDatabase()
+  const recordJson = JSON.stringify(record)
+  await db.sql`
+    UPDATE bluesky_shares
+    SET record_json = ${recordJson},
+        cover_image_url = NULL,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE source_activity_id = ${row.sourceActivityId}
+  `
+  row.recordJson = recordJson
+  row.coverImageUrl = null
+}
+
+async function markSharePosted(
+  row: BlueskyShareRow,
+  result: { uri: string; cid: string | null },
+): Promise<void> {
+  const db = useDatabase()
+  await db.sql`
+    UPDATE bluesky_shares
+    SET status = 'posted',
+        at_uri = ${result.uri},
+        cid = ${result.cid},
+        attempt_count = ${row.attemptCount + 1},
+        next_attempt_at = NULL,
+        last_error = NULL,
+        posted_at = CURRENT_TIMESTAMP,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE source_activity_id = ${row.sourceActivityId}
+  `
+}
+
+export async function queueBlueskyShare(
+  sourceActivityId: string,
+  entry: FedifyContentEntry,
+  now = new Date(),
+): Promise<boolean> {
+  const publicUrl = resolvePublicArticleUrl(entry)
+  if (!publicUrl) {
+    return false
+  }
+  const db = useDatabase()
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const draft = buildBlueskyShareDraft(entry, publicUrl, {
+      now,
+      siteOrigin: SITE_ORIGIN,
+    })
+    const result = await db.sql`
+      INSERT OR IGNORE INTO bluesky_shares (
+        source_activity_id,
+        source_url,
+        record_key,
+        record_json,
+        cover_image_url,
+        status,
+        attempt_count,
+        next_attempt_at
+      ) VALUES (
+        ${sourceActivityId},
+        ${publicUrl.href},
+        ${draft.recordKey},
+        ${JSON.stringify(draft.record)},
+        ${draft.coverImageUrl},
+        'pending',
+        0,
+        ${now.toISOString()}
+      )
+    `
+    if (changesValue(result) > 0) {
+      return true
+    }
+
+    const { rows } = await db.sql`
+      SELECT 1
+      FROM bluesky_shares
+      WHERE source_activity_id = ${sourceActivityId}
+      LIMIT 1
+    `
+    if (rows?.length) {
+      return false
+    }
+  }
+  throw new Error("Unable to reserve a unique Bluesky record key.")
+}
+
+function emptyResult(configuration: BlueskyConfig["status"], pending: number): BlueskyShareRunResult {
+  return {
+    configuration,
+    attempted: 0,
+    shared: 0,
+    pending,
+    failed: 0,
+    conflicts: 0,
+    thumbnailFallbacks: 0,
+  }
+}
+
+export async function processPendingBlueskyShares(
+  config: BlueskyConfig,
+  options: {
+    fetcher?: typeof fetch
+    now?: Date
+  } = {},
+): Promise<BlueskyShareRunResult> {
+  const now = options.now ?? new Date()
+  const fetcher = options.fetcher ?? fetch
+  const pendingBefore = await pendingShareCount()
+
+  if (config.status === "disabled") {
+    return emptyResult(config.status, pendingBefore)
+  }
+  if (config.status === "incomplete") {
+    console.error("Bluesky sharing is not configured: both BSKY_USER and BSKY_PASSWORD are required.")
+    return {
+      ...emptyResult(config.status, pendingBefore),
+      failed: pendingBefore > 0 ? 1 : 0,
+    }
+  }
+
+  const dueShares = await listDueShares(now)
+  const result = emptyResult(config.status, pendingBefore)
+  if (!dueShares.length) {
+    return result
+  }
+
+  let session
+  try {
+    session = await createBlueskySession(config, fetcher)
+  } catch (error) {
+    console.error(sanitizeBlueskyError(error))
+    for (const row of dueShares) {
+      try {
+        await markShareForRetry(row, error, now)
+      } catch {
+        console.error("Failed to persist a Bluesky share retry.")
+      }
+    }
+    result.attempted = dueShares.length
+    result.failed = dueShares.length
+    result.pending = await pendingShareCount()
+    return result
+  }
+
+  for (const row of dueShares) {
+    result.attempted += 1
+    try {
+      let record = parseBlueskyPostRecord(row.recordJson)
+      if (row.coverImageUrl) {
+        const thumbnail = await attachBlueskyCardThumbnail(
+          session,
+          record,
+          row.coverImageUrl,
+          fetcher,
+        )
+        record = thumbnail.record
+        if (thumbnail.outcome === "skipped") {
+          result.thumbnailFallbacks += 1
+        }
+        await persistPreparedRecord(row, record)
+      }
+
+      const posted = await createOrReconcileBlueskyPost(
+        session,
+        row.recordKey,
+        record,
+        fetcher,
+      )
+      await markSharePosted(row, posted)
+      result.shared += 1
+    } catch (error) {
+      result.failed += 1
+      console.error(sanitizeBlueskyError(error))
+      try {
+        if (error instanceof BlueskyRecordConflictError) {
+          await markShareConflict(row, error)
+          result.conflicts += 1
+        } else {
+          await markShareForRetry(row, error, now)
+        }
+      } catch {
+        console.error("Failed to persist a Bluesky share failure.")
+      }
+    }
+  }
+
+  result.pending = await pendingShareCount()
+  return result
+}

--- a/server/utils/fedify.ts
+++ b/server/utils/fedify.ts
@@ -54,9 +54,11 @@ import {
 import { persistFeedPostFromCreate } from "./activityPubFeed"
 import { ensureActivityPubSchema } from "./activityPubSchema"
 
-type CloudflareEnv = {
+export type CloudflareEnv = {
   FEDIFY_KV?: any
   FEDIFY_QUEUE?: any
+  BSKY_USER?: string
+  BSKY_PASSWORD?: string
 }
 
 export type FedifyContextData = {

--- a/server/utils/fedifyComments.ts
+++ b/server/utils/fedifyComments.ts
@@ -19,6 +19,8 @@ import {
 } from "./fedifyContent"
 import { ensureActivityPubSchema } from "./activityPubSchema"
 
+type TemporalInstant = ReturnType<typeof TemporalPolyfill.Now.instant>
+
 export type ActivityPubComment = {
   id: number
   objectId: string
@@ -126,12 +128,12 @@ function parseUrl(value?: string | null): URL | null {
   }
 }
 
-function parseInstant(value?: string | null): Temporal.Instant | null {
+function parseInstant(value?: string | null): TemporalInstant | null {
   if (!value) {
     return null
   }
   try {
-    return TemporalPolyfill.Instant.from(value) as unknown as Temporal.Instant
+    return TemporalPolyfill.Instant.from(value)
   } catch {
     return null
   }

--- a/server/utils/fedifyContent.ts
+++ b/server/utils/fedifyContent.ts
@@ -10,6 +10,8 @@ import { toHtml } from "hast-util-to-html"
 import { toHast } from "minimark/hast"
 import { stringify as stringifyMinimark } from "minimark/stringify"
 
+type TemporalInstant = ReturnType<typeof TemporalPolyfill.Now.instant>
+
 export const ACTOR_IDENTIFIER = "me"
 export const SITE_ORIGIN = "https://changkyun.kim"
 export const FEDIFY_BLOG_COLLECTION_PREFIX = "/blog"
@@ -26,6 +28,7 @@ export type FedifyContentEntry = {
   title?: string | null
   stem?: string | null
   description?: string | null
+  coverImage?: string | null
   createdAt?: string | Date | null
   draft?: boolean | null
   tags?: string[] | null
@@ -64,6 +67,7 @@ function toFedifyContentEntry(row: ContentRow): FedifyContentEntry {
     title: row.title ?? null,
     stem: row.stem ?? null,
     description: row.description ?? null,
+    coverImage: row.coverImage ?? null,
     createdAt: row.createdAt ?? null,
     draft: Boolean(meta && typeof meta === "object" && meta.draft === true),
     tags: normalizeTags(row.tags),
@@ -321,7 +325,7 @@ export function resolveArticleUrl(entry: FedifyContentEntry): URL | null {
   return new URL(path, SITE_ORIGIN)
 }
 
-function resolvePublicArticleUrl(entry: FedifyContentEntry): URL | null {
+export function resolvePublicArticleUrl(entry: FedifyContentEntry): URL | null {
   const path = resolveEntryPath(entry)
   if (!path) {
     return null
@@ -363,9 +367,9 @@ function resolveLegacyArticleUrls(entry: FedifyContentEntry, canonicalUrl: URL):
   return Array.from(legacy, (url) => new URL(url))
 }
 
-const instantFromIso = (iso: string): Temporal.Instant => TemporalPolyfill.Instant.from(iso) as unknown as Temporal.Instant
+const instantFromIso = (iso: string): TemporalInstant => TemporalPolyfill.Instant.from(iso)
 
-function normalizeDate(value?: string | Date | null): Temporal.Instant {
+function normalizeDate(value?: string | Date | null): TemporalInstant {
   const fallback = instantFromIso(new Date().toISOString())
   if (!value) {
     return fallback

--- a/tests/bluesky.test.ts
+++ b/tests/bluesky.test.ts
@@ -1,0 +1,349 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  attachBlueskyCardThumbnail,
+  BlueskyRecordConflictError,
+  buildBlueskyShareDraft,
+  createBlueskySession,
+  createOrReconcileBlueskyPost,
+  createBlueskyRecordKey,
+  nextBlueskyAttemptAt,
+  normalizeBlueskyText,
+  resolveBlueskyConfig,
+  sanitizeBlueskyError,
+  shouldQueueBlueskyShare,
+  truncateBlueskyText,
+  type BlueskyPostRecord,
+  type BlueskySession,
+} from "../server/utils/bluesky.ts"
+import { resolvePublicArticleUrl } from "../server/utils/fedifyContent.ts"
+
+const session: BlueskySession = {
+  accessJwt: "test-access-jwt",
+  did: "did:plc:test",
+  pdsUrl: "https://pds.example.com",
+}
+
+const record: BlueskyPostRecord = {
+  $type: "app.bsky.feed.post",
+  text: "간략한 요약",
+  createdAt: "2026-07-23T00:00:00.000Z",
+  embed: {
+    $type: "app.bsky.embed.external",
+    external: {
+      uri: "https://changkyun.blog/example",
+      title: "Example",
+      description: "간략한 요약",
+    },
+  },
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  })
+}
+
+test("resolves disabled, incomplete, and enabled secret configuration without exposing values", () => {
+  assert.deepEqual(resolveBlueskyConfig({}), { status: "disabled" })
+  assert.deepEqual(resolveBlueskyConfig({ BSKY_USER: "changkyun.kim" }), { status: "incomplete" })
+  assert.deepEqual(resolveBlueskyConfig({ BSKY_PASSWORD: "app-password" }), { status: "incomplete" })
+  assert.deepEqual(
+    resolveBlueskyConfig({
+      BSKY_USER: " changkyun.kim ",
+      BSKY_PASSWORD: " app-password ",
+    }),
+    {
+      status: "enabled",
+      user: "changkyun.kim",
+      password: "app-password",
+    },
+  )
+})
+
+test("normalizes Markdown, HTML, whitespace, and minimark-like content", () => {
+  assert.equal(
+    normalizeBlueskyText("## 제목\n\n[링크](https://example.com)와 <strong>강조</strong> &amp; `코드`"),
+    "제목 링크와 강조 & 코드",
+  )
+  assert.equal(
+    normalizeBlueskyText({
+      type: "minimark",
+      children: [
+        { type: "p", children: [{ type: "text", value: "본문" }] },
+        { type: "p", children: [{ type: "text", value: "요약" }] },
+      ],
+    }),
+    "본문 요약",
+  )
+})
+
+test("builds a stable summary and external-card draft with the canonical URL", () => {
+  const publicUrl = new URL("https://changkyun.blog/2026/example")
+  const draft = buildBlueskyShareDraft(
+    {
+      title: "새 글",
+      description: "  **간략한**\n요약  ",
+      coverImage: "/blog/example/cover.png",
+    },
+    publicUrl,
+    {
+      now: new Date("2026-07-23T00:00:00.000Z"),
+      siteOrigin: "https://changkyun.kim",
+    },
+  )
+
+  assert.match(draft.recordKey, /^[234567abcdefghij][234567abcdefghijklmnopqrstuvwxyz]{12}$/)
+  assert.equal(draft.record.text, "간략한 요약")
+  assert.equal(draft.record.createdAt, "2026-07-23T00:00:00.000Z")
+  assert.deepEqual(draft.record.embed.external, {
+    uri: publicUrl.href,
+    title: "새 글",
+    description: "간략한 요약",
+  })
+  assert.equal(draft.coverImageUrl, "https://changkyun.kim/blog/example/cover.png")
+})
+
+test("generates unique valid TID record keys within the same millisecond", () => {
+  const now = 1784764800000
+  const keys = new Set(Array.from({ length: 1100 }, () => createBlueskyRecordKey(now)))
+  keys.add(createBlueskyRecordKey(now + 1))
+  assert.equal(keys.size, 1101)
+  for (const key of keys) {
+    assert.match(key, /^[234567abcdefghij][234567abcdefghijklmnopqrstuvwxyz]{12}$/)
+  }
+})
+
+test("falls back from description to body and title", () => {
+  const fromBody = buildBlueskyShareDraft(
+    {
+      title: "제목",
+      body: { children: [{ value: "본문 요약" }] },
+    },
+    new URL("https://changkyun.blog/body"),
+  )
+  assert.equal(fromBody.record.text, "본문 요약")
+
+  const fromTitle = buildBlueskyShareDraft(
+    { title: "제목만 있음" },
+    new URL("https://changkyun.blog/title"),
+  )
+  assert.equal(fromTitle.record.text, "제목만 있음")
+})
+
+test("selects browser-facing canonical URLs for blog and app entries", () => {
+  assert.equal(
+    resolvePublicArticleUrl({ path: "/blog/2026/example" })?.href,
+    "https://changkyun.blog/2026/example",
+  )
+  assert.equal(
+    resolvePublicArticleUrl({ path: "/app/cube-timer" })?.href,
+    "https://changkyun.kim/app/cube-timer",
+  )
+})
+
+test("truncates at grapheme and UTF-8 byte limits without splitting emoji", () => {
+  const korean = truncateBlueskyText("가".repeat(400))
+  assert.equal(Array.from(new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(korean)).length, 300)
+  assert.equal(new TextEncoder().encode(korean).byteLength, 900)
+
+  assert.equal(truncateBlueskyText("가나다", 300, 7), "가나")
+
+  const family = "👨‍👩‍👧‍👦"
+  assert.equal(truncateBlueskyText(`${family}${family}`, 1, 100), family)
+})
+
+test("creates a session and routes writes to the returned HTTPS PDS", async () => {
+  let requestBody: Record<string, string> | null = null
+  const fetcher: typeof fetch = async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return jsonResponse({
+      accessJwt: "access",
+      refreshJwt: "refresh",
+      did: "did:plc:test",
+      handle: "changkyun.kim",
+      didDoc: {
+        service: [{
+          id: "did:plc:test#atproto_pds",
+          type: "AtprotoPersonalDataServer",
+          serviceEndpoint: "https://pds.example.com/",
+        }],
+      },
+    })
+  }
+
+  const created = await createBlueskySession({
+    status: "enabled",
+    user: "changkyun.kim",
+    password: "app-password",
+  }, fetcher)
+
+  assert.deepEqual(requestBody, {
+    identifier: "changkyun.kim",
+    password: "app-password",
+  })
+  assert.deepEqual(created, {
+    accessJwt: "access",
+    did: "did:plc:test",
+    pdsUrl: "https://pds.example.com",
+  })
+})
+
+test("uploads an eligible cover image and attaches the returned blob", async () => {
+  const requests: string[] = []
+  const fetcher: typeof fetch = async (input) => {
+    const url = String(input)
+    requests.push(url)
+    if (url === "https://changkyun.kim/cover.png") {
+      return new Response(new Uint8Array([1, 2, 3]), {
+        headers: {
+          "content-type": "image/png",
+          "content-length": "3",
+        },
+      })
+    }
+    assert.equal(url, "https://pds.example.com/xrpc/com.atproto.repo.uploadBlob")
+    return jsonResponse({
+      blob: {
+        $type: "blob",
+        ref: { $link: "bafktest" },
+        mimeType: "image/png",
+        size: 3,
+      },
+    })
+  }
+
+  const result = await attachBlueskyCardThumbnail(
+    session,
+    record,
+    "https://changkyun.kim/cover.png",
+    fetcher,
+  )
+
+  assert.equal(result.outcome, "attached")
+  assert.deepEqual(result.record.embed.external.thumb, {
+    $type: "blob",
+    ref: { $link: "bafktest" },
+    mimeType: "image/png",
+    size: 3,
+  })
+  assert.equal(requests.length, 2)
+})
+
+test("degrades oversized and non-image covers to a card without a thumbnail", async () => {
+  let requests = 0
+  const oversized: typeof fetch = async () => {
+    requests += 1
+    return new Response(new Uint8Array(), {
+      headers: {
+        "content-type": "image/png",
+        "content-length": "1000001",
+      },
+    })
+  }
+  const oversizedResult = await attachBlueskyCardThumbnail(
+    session,
+    record,
+    "https://changkyun.kim/large.png",
+    oversized,
+  )
+  assert.equal(oversizedResult.outcome, "skipped")
+  assert.equal(oversizedResult.record.embed.external.thumb, undefined)
+  assert.equal(requests, 1)
+
+  const nonImageResult = await attachBlueskyCardThumbnail(
+    session,
+    record,
+    "https://changkyun.kim/not-image",
+    async () => new Response("html", {
+      headers: { "content-type": "text/html" },
+    }),
+  )
+  assert.equal(nonImageResult.outcome, "skipped")
+})
+
+test("reconciles an already-created matching record without another POST", async () => {
+  let calls = 0
+  const fetcher: typeof fetch = async (_input, init) => {
+    calls += 1
+    assert.equal(init?.method, "GET")
+    return jsonResponse({
+      uri: "at://did:plc:test/app.bsky.feed.post/3mtest",
+      cid: "bafytest",
+      value: record,
+    })
+  }
+
+  const result = await createOrReconcileBlueskyPost(session, "3mtestrecord2", record, fetcher)
+  assert.deepEqual(result, {
+    uri: "at://did:plc:test/app.bsky.feed.post/3mtest",
+    cid: "bafytest",
+  })
+  assert.equal(calls, 1)
+})
+
+test("recovers a lost create response by reading the same persisted record key", async () => {
+  let calls = 0
+  const fetcher: typeof fetch = async (_input, init) => {
+    calls += 1
+    if (calls === 1) {
+      assert.equal(init?.method, "GET")
+      return jsonResponse({ error: "RecordNotFound" }, 404)
+    }
+    if (calls === 2) {
+      assert.equal(init?.method, "POST")
+      throw new TypeError("simulated connection loss")
+    }
+    assert.equal(init?.method, "GET")
+    return jsonResponse({
+      uri: "at://did:plc:test/app.bsky.feed.post/3mtest",
+      cid: "bafytest",
+      value: record,
+    })
+  }
+
+  const result = await createOrReconcileBlueskyPost(session, "3mtestrecord2", record, fetcher)
+  assert.equal(result.uri, "at://did:plc:test/app.bsky.feed.post/3mtest")
+  assert.equal(calls, 3)
+})
+
+test("refuses to overwrite a different record at the persisted key", async () => {
+  const fetcher: typeof fetch = async () => jsonResponse({
+    uri: "at://did:plc:test/app.bsky.feed.post/3mtest",
+    cid: "bafydifferent",
+    value: {
+      ...record,
+      text: "different",
+    },
+  })
+
+  await assert.rejects(
+    createOrReconcileBlueskyPost(session, "3mtestrecord2", record, fetcher),
+    BlueskyRecordConflictError,
+  )
+})
+
+test("sanitizes unexpected errors instead of retaining credential-bearing messages", () => {
+  const sanitized = sanitizeBlueskyError(new Error("app-password leaked in a transport error"))
+  assert.equal(sanitized, "Bluesky sharing failed.")
+  assert.equal(sanitized.includes("app-password"), false)
+})
+
+test("uses bounded exponential backoff for pending Bluesky shares", () => {
+  const now = new Date("2026-07-23T00:00:00.000Z")
+  assert.equal(nextBlueskyAttemptAt(1, now), "2026-07-23T00:10:00.000Z")
+  assert.equal(nextBlueskyAttemptAt(2, now), "2026-07-23T00:20:00.000Z")
+  assert.equal(nextBlueskyAttemptAt(3, now), "2026-07-23T00:40:00.000Z")
+  assert.equal(nextBlueskyAttemptAt(20, now), "2026-07-23T06:00:00.000Z")
+})
+
+test("queues only newly published activities and never backfills an existing outbox", () => {
+  assert.equal(shouldQueueBlueskyShare("enabled", false), true)
+  assert.equal(shouldQueueBlueskyShare("incomplete", false), true)
+  assert.equal(shouldQueueBlueskyShare("enabled", true), false)
+  assert.equal(shouldQueueBlueskyShare("disabled", false), false)
+})


### PR DESCRIPTION
## Summary

- add a dependency-free AT Protocol XRPC client for one-way Bluesky link-card posts
- persist deterministic record keys and post payloads in D1 for idempotent retries and response-loss reconciliation
- queue only newly published ActivityPub blog/app entries, while isolating Bluesky failures from ActivityPub delivery
- attach eligible cover images as external-card thumbnails with a no-thumbnail fallback
- document Cloudflare secrets, operational status, and the intentionally create-only synchronization boundary

## Review follow-up

- `3dda529` explicitly forwards Cloudflare env bindings through Nitro task context from both scheduled and manual publication callers

## Validation

- `pnpm test` (16 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- SQLite migration and duplicate-insert smoke test
- production bundle check confirming Bluesky identifiers are server-only

## Notes

A live credentialed Bluesky smoke test was not run because repository or account secrets were not available locally. Authentication, record creation, retry, response-loss reconciliation, conflict handling, Unicode limits, and thumbnail fallback are covered with mocked XRPC tests.

Closes #514